### PR TITLE
add the ability to use fonts from the google_fonts package

### DIFF
--- a/lib/frontend/terminal_view.dart
+++ b/lib/frontend/terminal_view.dart
@@ -53,11 +53,15 @@ class TerminalView extends StatefulWidget {
 
     final text = Text(
       testString,
-      style: TextStyle(
-        fontFamily: 'monospace',
-        fontFamilyFallback: style.fontFamily,
-        fontSize: style.fontSize,
-      ),
+      style: (style.textStyleProvider != null)
+          ? style.textStyleProvider(
+              fontSize: style.fontSize,
+            )
+          : TextStyle(
+              fontFamily: 'monospace',
+              fontFamilyFallback: style.fontFamily,
+              fontSize: style.fontSize,
+            ),
     );
 
     final size = textSize(text);
@@ -425,16 +429,26 @@ class TerminalPainter extends CustomPainter {
       color = color.withOpacity(0.5);
     }
 
-    final style = TextStyle(
-        color: color,
-        fontWeight: cell.attr.bold ? FontWeight.bold : FontWeight.normal,
-        fontStyle: cell.attr.italic ? FontStyle.italic : FontStyle.normal,
-        fontSize: view.style.fontSize,
-        decoration: cell.attr.underline
-            ? TextDecoration.underline
-            : TextDecoration.none,
-        fontFamily: 'monospace',
-        fontFamilyFallback: view.style.fontFamily);
+    final style = (view.style.textStyleProvider != null)
+        ? view.style.textStyleProvider(
+            color: color,
+            fontWeight: cell.attr.bold ? FontWeight.bold : FontWeight.normal,
+            fontStyle: cell.attr.italic ? FontStyle.italic : FontStyle.normal,
+            fontSize: view.style.fontSize,
+            decoration: cell.attr.underline
+                ? TextDecoration.underline
+                : TextDecoration.none,
+          )
+        : TextStyle(
+            color: color,
+            fontWeight: cell.attr.bold ? FontWeight.bold : FontWeight.normal,
+            fontStyle: cell.attr.italic ? FontStyle.italic : FontStyle.normal,
+            fontSize: view.style.fontSize,
+            decoration: cell.attr.underline
+                ? TextDecoration.underline
+                : TextDecoration.none,
+            fontFamily: 'monospace',
+            fontFamilyFallback: view.style.fontFamily);
 
     final span = TextSpan(
       text: String.fromCharCode(cell.codePoint),

--- a/lib/theme/terminal_style.dart
+++ b/lib/theme/terminal_style.dart
@@ -1,3 +1,6 @@
+import 'dart:ui' as ui;
+import 'package:flutter/material.dart';
+
 class TerminalStyle {
   static const defaultFontFamily = [
     'Monaco',
@@ -28,10 +31,34 @@ class TerminalStyle {
     this.fontSize = 14,
     this.fontWidthScaleFactor = 1.0,
     this.fontHeightScaleFactor = 1.1,
+    this.textStyleProvider,
   });
 
   final List<String> fontFamily;
   final double fontSize;
   final double fontWidthScaleFactor;
   final double fontHeightScaleFactor;
+  final TextStyleProvider textStyleProvider;
 }
+
+typedef TextStyleProvider = Function({
+  TextStyle textStyle,
+  Color color,
+  Color backgroundColor,
+  double fontSize,
+  FontWeight fontWeight,
+  FontStyle fontStyle,
+  double letterSpacing,
+  double wordSpacing,
+  TextBaseline textBaseline,
+  double height,
+  Locale locale,
+  Paint foreground,
+  Paint background,
+  List<ui.Shadow> shadows,
+  List<ui.FontFeature> fontFeatures,
+  TextDecoration decoration,
+  Color decorationColor,
+  TextDecorationStyle decorationStyle,
+  double decorationThickness,
+});


### PR DESCRIPTION
This adds a new optional `textStyleProvider` parameter to the `TerminalStyle` constructor. The parameter has a function type, and when a function is provided, the `TerminalView` class calls this function to get the `TextStyle` to use for drawing in the terminal. This allows fonts from the [google_fonts](https://pub.dev/packages/google_fonts) package to be easily used in terminals. Clients only need to pass the `GoogleFonts` function for the desired font, e.g.
```
TerminalView(
  terminal: TerminalProvider.of(context),
  scrollController: scrollController,
  style: TerminalStyle(
    fontSize: 30,
    textStyleProvider: GoogleFonts.inconsolata,
  ),
)
```

For backward compatibility, this parameter can be omitted and text styles will be constructed as before.

Note that the change does not add a direct dependency on `google_fonts`. Instead, the new `TextStyleProvider` type in `terminal_style.dart` matches the function type used in `google_fonts`. If that type changes, `TextStyleProvider` may need to be updated.