### PR TITLE
Pass TerminalView's autofocus to the InputListener that it creates.

### DIFF
--- a/lib/frontend/terminal_view.dart
+++ b/lib/frontend/terminal_view.dart
@@ -154,7 +154,7 @@ class _TerminalViewState extends State<TerminalView> {
       onAction: onAction,
       onFocus: onFocus,
       focusNode: widget.focusNode,
-      autofocus: false,
+      autofocus: widget.autofocus,
       initEditingState: widget.inputBehavior.initEditingState,
       child: MouseRegion(
         cursor: SystemMouseCursors.text,


### PR DESCRIPTION
I noticed that setting autofocus=true in the TerminalView constructor didn't seem to cause the TerminalView to take focus, but when I made this change to pass the TerminalView's autofocus setting down to the InputListener, it worked - the TerminalView took focus when my app started (on Linux and web).

At the [point of change](https://github.com/TerminalStudio/xterm.dart/blob/ef6fb4aa1cbc6af2e6874bcbc3a0974ee7d3e30a/lib/frontend/terminal_view.dart#L157), the InputListener autofocus was intentionally set to false (and had at one time been true), but this may have been done before there was a TerminalView autofocus value to use there.

This change should have no effect when the TerminalView's autofocus is false (the default).