### PR TITLE
Adds handling of the "compose" input state

### DIFF
--- a/lib/frontend/input_behavior_default.dart
+++ b/lib/frontend/input_behavior_default.dart
@@ -39,12 +39,12 @@ class InputBehaviorDefault extends InputBehavior {
     // about it
     if (value.composing.start != value.composing.end) {
       _composingString = (_composingString ?? '') + value.text;
-      terminal.updateComposingString(true, _composingString!);
+      terminal.updateComposingString(_composingString!);
       return null;
     }
     if (_composingString != null) {
       _composingString = null;
-      terminal.updateComposingString(false, '');
+      terminal.updateComposingString('');
     }
     terminal.onInput(value.text);
     if (value == TextEditingValue.empty || value.text == '') {

--- a/lib/frontend/input_behavior_default.dart
+++ b/lib/frontend/input_behavior_default.dart
@@ -47,9 +47,7 @@ class InputBehaviorDefault extends InputBehavior {
       terminal.updateComposingString(false, '');
     }
     terminal.onInput(value.text);
-    if (value == TextEditingValue.empty ||
-        value.text == null ||
-        value.text == '') {
+    if (value == TextEditingValue.empty || value.text == '') {
       return null;
     } else {
       return TextEditingValue.empty;

--- a/lib/frontend/input_behavior_default.dart
+++ b/lib/frontend/input_behavior_default.dart
@@ -37,7 +37,7 @@ class InputBehaviorDefault extends InputBehavior {
   @override
   TextEditingValue? onTextEdit(TextEditingValue value, Terminal terminal) {
     var inputText = value.text;
-    print('INPUT: "${value.text}" ${value.composing} | ${value.selection}');
+    //print('INPUT: "${value.text}" ${value.composing} | ${value.selection}');
     // we just want to detect if a composing is going on and notify the terminal
     // about it
     if (value.composing.start != value.composing.end) {

--- a/lib/frontend/input_behavior_default.dart
+++ b/lib/frontend/input_behavior_default.dart
@@ -5,7 +5,7 @@ import 'package:xterm/frontend/input_map.dart';
 import 'package:xterm/xterm.dart';
 
 class InputBehaviorDefault extends InputBehavior {
-  const InputBehaviorDefault();
+  InputBehaviorDefault();
 
   @override
   bool get acceptKeyStroke => true;
@@ -31,10 +31,25 @@ class InputBehaviorDefault extends InputBehavior {
     }
   }
 
+  String? _composingString = null;
+
   @override
   TextEditingValue? onTextEdit(TextEditingValue value, Terminal terminal) {
+    // we just want to detect if a composing is going on and notify the terminal
+    // about it
+    if (value.composing.start != value.composing.end) {
+      _composingString = (_composingString ?? '') + value.text;
+      terminal.updateComposingString(true, _composingString!);
+      return null;
+    }
+    if (_composingString != null) {
+      _composingString = null;
+      terminal.updateComposingString(false, '');
+    }
     terminal.onInput(value.text);
-    if (value == TextEditingValue.empty) {
+    if (value == TextEditingValue.empty ||
+        value.text == null ||
+        value.text == '') {
       return null;
     } else {
       return TextEditingValue.empty;

--- a/lib/frontend/input_behavior_default.dart
+++ b/lib/frontend/input_behavior_default.dart
@@ -32,22 +32,35 @@ class InputBehaviorDefault extends InputBehavior {
   }
 
   String? _composingString = null;
+  String? _ignoreChar;
 
   @override
   TextEditingValue? onTextEdit(TextEditingValue value, Terminal terminal) {
+    var inputText = value.text;
+    print('INPUT: "${value.text}" ${value.composing} | ${value.selection}');
     // we just want to detect if a composing is going on and notify the terminal
     // about it
     if (value.composing.start != value.composing.end) {
-      _composingString = (_composingString ?? '') + value.text;
+      _composingString = inputText;
       terminal.updateComposingString(_composingString!);
       return null;
     }
+    if (_ignoreChar != null && inputText != '') {
+      if (inputText.startsWith(_ignoreChar!)) {
+        inputText = inputText.substring(_ignoreChar!.length);
+      }
+      _ignoreChar = null;
+    }
     if (_composingString != null) {
+      // we ignore the just commited string the next time
+      // as the input system sends it again together with
+      // the next character
+      _ignoreChar = _composingString;
       _composingString = null;
       terminal.updateComposingString('');
     }
-    terminal.onInput(value.text);
-    if (value == TextEditingValue.empty || value.text == '') {
+    terminal.onInput(inputText);
+    if (value == TextEditingValue.empty || inputText == '') {
       return null;
     } else {
       return TextEditingValue.empty;

--- a/lib/frontend/input_behavior_desktop.dart
+++ b/lib/frontend/input_behavior_desktop.dart
@@ -1,5 +1,5 @@
 import 'package:xterm/frontend/input_behavior_default.dart';
 
 class InputBehaviorDesktop extends InputBehaviorDefault {
-  const InputBehaviorDesktop();
+  InputBehaviorDesktop();
 }

--- a/lib/frontend/input_behavior_mobile.dart
+++ b/lib/frontend/input_behavior_mobile.dart
@@ -5,7 +5,7 @@ import 'package:xterm/input/keys.dart';
 import 'package:xterm/xterm.dart';
 
 class InputBehaviorMobile extends InputBehaviorDefault {
-  const InputBehaviorMobile();
+  InputBehaviorMobile();
 
   final acceptKeyStroke = false;
 

--- a/lib/frontend/input_behaviors.dart
+++ b/lib/frontend/input_behaviors.dart
@@ -4,9 +4,9 @@ import 'package:xterm/frontend/input_behavior_desktop.dart';
 import 'package:xterm/frontend/input_behavior_mobile.dart';
 
 class InputBehaviors {
-  static const desktop = InputBehaviorDesktop();
+  static final desktop = InputBehaviorDesktop();
 
-  static const mobile = InputBehaviorMobile();
+  static final mobile = InputBehaviorMobile();
 
   static InputBehavior get platform {
     if (Platform.I.isMobile) {

--- a/lib/terminal/terminal.dart
+++ b/lib/terminal/terminal.dart
@@ -201,7 +201,7 @@ class Terminal with Observable {
   String _composingString = '';
   String get composingString => _composingString;
 
-  void updateComposingString(bool isActive, String value) {
+  void updateComposingString(String value) {
     _composingString = value;
     notifyListeners();
   }

--- a/lib/terminal/terminal.dart
+++ b/lib/terminal/terminal.dart
@@ -198,6 +198,14 @@ class Terminal with Observable {
   int get cursorY => buffer.cursorY;
   int get scrollOffset => buffer.scrollOffsetFromBottom;
 
+  String _composingString = '';
+  String get composingString => _composingString;
+
+  void updateComposingString(bool isActive, String value) {
+    _composingString = value;
+    notifyListeners();
+  }
+
   /// Writes data to the terminal. Terminal sequences and special characters are
   /// interpreted.
   ///


### PR DESCRIPTION
This adds a "compose" input state to the terminal and the default input behavior tries to detect such a state and reflects it to the Terminal.
The TerminalView draws the current compose state into the Cursor (not sure what color to use there)

This should enable the Terminal to handle "^", "~", ... as well as "â", "ñ", ...