### PR TITLE
Handle mac input specialties

### DIFF
--- a/lib/frontend/input_behavior_default.dart
+++ b/lib/frontend/input_behavior_default.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:xterm/frontend/input_behavior.dart';
@@ -28,7 +26,7 @@ class InputBehaviorDefault extends InputBehavior {
           ctrl: event.isControlPressed,
           alt: event.isAltPressed,
           shift: event.isShiftPressed,
-          mac: Platform.isMacOS);
+          mac: terminal.platform.useMacInputBehavior);
     }
   }
 

--- a/lib/frontend/input_behavior_default.dart
+++ b/lib/frontend/input_behavior_default.dart
@@ -22,11 +22,13 @@ class InputBehaviorDefault extends InputBehavior {
     final key = inputMap(event.logicalKey);
 
     if (key != null) {
-      terminal.keyInput(key,
-          ctrl: event.isControlPressed,
-          alt: event.isAltPressed,
-          shift: event.isShiftPressed,
-          mac: terminal.platform.useMacInputBehavior);
+      terminal.keyInput(
+        key,
+        ctrl: event.isControlPressed,
+        alt: event.isAltPressed,
+        shift: event.isShiftPressed,
+        mac: terminal.platform.useMacInputBehavior,
+      );
     }
   }
 

--- a/lib/frontend/input_behavior_default.dart
+++ b/lib/frontend/input_behavior_default.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:xterm/frontend/input_behavior.dart';
@@ -22,12 +24,11 @@ class InputBehaviorDefault extends InputBehavior {
     final key = inputMap(event.logicalKey);
 
     if (key != null) {
-      terminal.keyInput(
-        key,
-        ctrl: event.isControlPressed,
-        alt: event.isAltPressed,
-        shift: event.isShiftPressed,
-      );
+      terminal.keyInput(key,
+          ctrl: event.isControlPressed,
+          alt: event.isAltPressed,
+          shift: event.isShiftPressed,
+          mac: Platform.isMacOS);
     }
   }
 

--- a/lib/input/keytab/keytab_default.dart
+++ b/lib/input/keytab/keytab_default.dart
@@ -74,11 +74,18 @@ key Left  -Shift-AnyMod+Ansi-AppCuKeys : "\E[D"
 
 key Up    -Shift+AnyMod+Ansi           : "\E[1;5A"
 key Down  -Shift+AnyMod+Ansi           : "\E[1;5B"
-key Right -Shift+AnyMod+Ansi-Mac       : "\E[1;5C"
-key Left  -Shift+AnyMod+Ansi-Mac       : "\E[1;5D"
 
-key Right -Shift+AnyMod+Ansi+Mac       : "\Ef"
-key Left  -Shift+AnyMod+Ansi+Mac       : "\Eb"
+# Right / Left with Control
+key Right -Shift-Alt+Control+Ansi      : "\E[1;5C"
+key Left  -Shift-Alt+Control+Ansi      : "\E[1;5D"
+
+# Right / Left with Alt not on a Mac
+key Right -Shift+Alt-Control+Ansi-Mac  : "\E[1;5C"
+key Left  -Shift+Alt-Control+Ansi-Mac  : "\E[1;5D"
+
+# Right / Left with Alt on a Mac
+key Right -Shift+Alt-Control+Ansi+Mac  : "\Ef"
+key Left  -Shift+Alt-Control+Ansi+Mac  : "\Eb"
 
 key Up    +Shift+AppScreen             : "\E[1;*A"
 key Down  +Shift+AppScreen             : "\E[1;*B"

--- a/lib/input/keytab/keytab_default.dart
+++ b/lib/input/keytab/keytab_default.dart
@@ -74,8 +74,11 @@ key Left  -Shift-AnyMod+Ansi-AppCuKeys : "\E[D"
 
 key Up    -Shift+AnyMod+Ansi           : "\E[1;5A"
 key Down  -Shift+AnyMod+Ansi           : "\E[1;5B"
-key Right -Shift+AnyMod+Ansi           : "\E[1;5C"
-key Left  -Shift+AnyMod+Ansi           : "\E[1;5D"
+key Right -Shift+AnyMod+Ansi-Mac       : "\E[1;5C"
+key Left  -Shift+AnyMod+Ansi-Mac       : "\E[1;5D"
+
+key Right -Shift+AnyMod+Ansi+Mac       : "\Ef"
+key Left  -Shift+AnyMod+Ansi+Mac       : "\Eb"
 
 key Up    +Shift+AppScreen             : "\E[1;*A"
 key Down  +Shift+AppScreen             : "\E[1;*B"

--- a/lib/input/keytab/keytab_parse.dart
+++ b/lib/input/keytab/keytab_parse.dart
@@ -165,20 +165,21 @@ class KeytabParser {
     }
 
     final record = KeytabRecord(
-        qtKeyName: keyName.value,
-        key: key,
-        action: action,
-        alt: alt,
-        ctrl: ctrl,
-        shift: shift,
-        anyModifier: anyModifier,
-        ansi: ansi,
-        appScreen: appScreen,
-        keyPad: keyPad,
-        appCursorKeys: appCursorKeys,
-        appKeyPad: appKeyPad,
-        newLine: newLine,
-        mac: mac);
+      qtKeyName: keyName.value,
+      key: key,
+      action: action,
+      alt: alt,
+      ctrl: ctrl,
+      shift: shift,
+      anyModifier: anyModifier,
+      ansi: ansi,
+      appScreen: appScreen,
+      keyPad: keyPad,
+      appCursorKeys: appCursorKeys,
+      appKeyPad: appKeyPad,
+      newLine: newLine,
+      mac: mac,
+    );
 
     _records.add(record);
   }

--- a/lib/input/keytab/keytab_parse.dart
+++ b/lib/input/keytab/keytab_parse.dart
@@ -91,6 +91,7 @@ class KeytabParser {
     bool? appCursorKeys;
     bool? appKeyPad;
     bool? newLine;
+    bool? mac;
 
     while (reader.peek()!.type == KeytabTokenType.modeStatus) {
       bool modeStatus;
@@ -141,6 +142,9 @@ class KeytabParser {
         case 'NewLine':
           newLine = modeStatus;
           break;
+        case 'Mac':
+          mac = modeStatus;
+          break;
         default:
           throw ParseError();
       }
@@ -161,20 +165,20 @@ class KeytabParser {
     }
 
     final record = KeytabRecord(
-      qtKeyName: keyName.value,
-      key: key,
-      action: action,
-      alt: alt,
-      ctrl: ctrl,
-      shift: shift,
-      anyModifier: anyModifier,
-      ansi: ansi,
-      appScreen: appScreen,
-      keyPad: keyPad,
-      appCursorKeys: appCursorKeys,
-      appKeyPad: appKeyPad,
-      newLine: newLine,
-    );
+        qtKeyName: keyName.value,
+        key: key,
+        action: action,
+        alt: alt,
+        ctrl: ctrl,
+        shift: shift,
+        anyModifier: anyModifier,
+        ansi: ansi,
+        appScreen: appScreen,
+        keyPad: keyPad,
+        appCursorKeys: appCursorKeys,
+        appKeyPad: appKeyPad,
+        newLine: newLine,
+        mac: mac);
 
     _records.add(record);
   }

--- a/lib/input/keytab/keytab_record.dart
+++ b/lib/input/keytab/keytab_record.dart
@@ -39,6 +39,7 @@ class KeytabRecord {
     required this.appCursorKeys,
     required this.appKeyPad,
     required this.newLine,
+    required this.mac,
   });
 
   String qtKeyName;
@@ -55,6 +56,7 @@ class KeytabRecord {
   bool? appCursorKeys;
   bool? appKeyPad;
   bool? newLine;
+  bool? mac;
 
   @override
   String toString() {
@@ -99,6 +101,10 @@ class KeytabRecord {
 
     if (newLine != null) {
       buffer.write(modeStatus(newLine!, 'NewLine'));
+    }
+
+    if (mac != null) {
+      buffer.write(modeStatus(mac!, 'Mac'));
     }
 
     buffer.write(' : $action');

--- a/lib/terminal/platform.dart
+++ b/lib/terminal/platform.dart
@@ -1,10 +1,16 @@
 class PlatformBehavior {
-  const PlatformBehavior({required this.oscTerminators});
+  const PlatformBehavior(
+      {required this.oscTerminators, required this.useMacInputBehavior});
 
   final Set<int> oscTerminators;
+  final bool useMacInputBehavior;
 }
 
 class PlatformBehaviors {
-  static const unix = PlatformBehavior(oscTerminators: {0x07, 0x5c});
-  static const windows = PlatformBehavior(oscTerminators: {0x07, 0x00});
+  static const mac =
+      PlatformBehavior(oscTerminators: {0x07, 0x5c}, useMacInputBehavior: true);
+  static const unix = PlatformBehavior(
+      oscTerminators: {0x07, 0x5c}, useMacInputBehavior: false);
+  static const windows = PlatformBehavior(
+      oscTerminators: {0x07, 0x00}, useMacInputBehavior: false);
 }

--- a/lib/terminal/platform.dart
+++ b/lib/terminal/platform.dart
@@ -1,16 +1,26 @@
 class PlatformBehavior {
-  const PlatformBehavior(
-      {required this.oscTerminators, required this.useMacInputBehavior});
+  const PlatformBehavior({
+    required this.oscTerminators,
+    required this.useMacInputBehavior,
+  });
 
   final Set<int> oscTerminators;
   final bool useMacInputBehavior;
 }
 
 class PlatformBehaviors {
-  static const mac =
-      PlatformBehavior(oscTerminators: {0x07, 0x5c}, useMacInputBehavior: true);
+  static const mac = PlatformBehavior(
+    oscTerminators: {0x07, 0x5c},
+    useMacInputBehavior: true,
+  );
+
   static const unix = PlatformBehavior(
-      oscTerminators: {0x07, 0x5c}, useMacInputBehavior: false);
+    oscTerminators: {0x07, 0x5c},
+    useMacInputBehavior: false,
+  );
+
   static const windows = PlatformBehavior(
-      oscTerminators: {0x07, 0x00}, useMacInputBehavior: false);
+    oscTerminators: {0x07, 0x00},
+    useMacInputBehavior: false,
+  );
 }

--- a/lib/terminal/terminal.dart
+++ b/lib/terminal/terminal.dart
@@ -364,6 +364,7 @@ class Terminal with Observable {
     bool ctrl = false,
     bool alt = false,
     bool shift = false,
+    bool mac = false,
     // bool meta,
   }) {
     debug.onMsg(key);
@@ -405,6 +406,10 @@ class Terminal with Observable {
 
       if (record.appCursorKeys != null &&
           record.appCursorKeys != applicationCursorKeys) {
+        continue;
+      }
+
+      if (record.mac != null && record.mac != mac) {
         continue;
       }
 


### PR DESCRIPTION
Another try. The last PR got lost because of merge / undo.
The Terminal now can be set to "Mac mode" by using PlatformBehaviors.mac