### PR TITLE
Fixes wrong delete behavior

### DIFF
--- a/lib/buffer/buffer.dart
+++ b/lib/buffer/buffer.dart
@@ -422,7 +422,7 @@ class Buffer {
   void deleteChars(int count) {
     final start = _cursorX.clamp(0, terminal.viewWidth);
     final end = min(_cursorX + count, terminal.viewWidth);
-    currentLine.clearRange(start, end);
+    currentLine.removeRange(start, end);
   }
 
   void clearScrollback() {

--- a/lib/buffer/buffer_line.dart
+++ b/lib/buffer/buffer_line.dart
@@ -259,12 +259,13 @@ class BufferLine {
   //   return a ^ b;
   // }
 
+  void removeRange(int start, int end) {
+    end = min(end, _maxCols);
+    this.removeN(start, end - start);
+  }
+
   void clearRange(int start, int end) {
     end = min(end, _maxCols);
-    // start = start.clamp(0, _cells.length);
-    // end ??= _cells.length;
-    // end = end.clamp(start, _cells.length);
-    // _cells.removeRange(start, end);
     for (var index = start; index < end; index++) {
       cellClear(index);
     }


### PR DESCRIPTION
Instead of just clearing out the cells they now get removed.
This fixes an issue when the delete key is used like here:
![CleanShot 2021-04-13 at 20 40 20](https://user-images.githubusercontent.com/6693130/114603950-a446d680-9c98-11eb-9eb6-33152859f293.gif)
