### PR TITLE
asynchronous file io and terminal logic

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -23,16 +23,16 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key? key}) : super(key: key);
+  MyHomePage({Key key}) : super(key: key);
 
   @override
   _MyHomePageState createState() => _MyHomePageState();
 }
 
 class FakeTerminalBackend implements TerminalBackend {
-  late Completer<int> _exitCodeCompleter;
+  Completer<int> _exitCodeCompleter;
   // ignore: close_sinks
-  late StreamController<String> _outStream;
+  StreamController<String> _outStream;
 
   FakeTerminalBackend();
 
@@ -79,7 +79,7 @@ class FakeTerminalBackend implements TerminalBackend {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  late TerminalIsolate terminal;
+  TerminalIsolate terminal;
 
   @override
   void initState() {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -76,6 +76,11 @@ class FakeTerminalBackend implements TerminalBackend {
       _outStream.sink.add(input);
     }
   }
+
+  @override
+  void terminate() {
+    //NOOP
+  }
 }
 
 class _MyHomePageState extends State<MyHomePage> {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:xterm/flutter.dart';
 import 'package:xterm/xterm.dart';
@@ -21,44 +23,75 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key key}) : super(key: key);
+  MyHomePage({Key? key}) : super(key: key);
 
   @override
   _MyHomePageState createState() => _MyHomePageState();
 }
 
-class _MyHomePageState extends State<MyHomePage> {
-  Terminal terminal;
+class FakeTerminalBackend implements TerminalBackend {
+  late Completer<int> _exitCodeCompleter;
+  // ignore: close_sinks
+  late StreamController<String> _outStream;
+
+  FakeTerminalBackend();
 
   @override
-  void initState() {
-    super.initState();
-    terminal = Terminal(
-      onInput: onInput,
-      maxLines: 10000,
-    );
-    terminal.write('xterm.dart demo');
-    terminal.write('\r\n');
-    terminal.write('\$ ');
+  Future<int> get exitCode => _exitCodeCompleter.future;
+
+  @override
+  void init() {
+    _exitCodeCompleter = Completer<int>();
+    _outStream = StreamController<String>();
+    _outStream.sink.add('xterm.dart demo');
+    _outStream.sink.add('\r\n');
+    _outStream.sink.add('\$ ');
   }
 
-  void onInput(String input) {
+  @override
+  Stream<String> get out => _outStream.stream;
+
+  @override
+  void resize(int width, int height) {
+    // NOOP
+  }
+
+  @override
+  void write(String input) {
+    if (input.length <= 0) {
+      return;
+    }
     // in a "real" terminal emulation you would connect onInput to the backend
     // (like a pty or ssh connection) that then handles the changes in the
     // terminal.
     // As we don't have a connected backend here we simulate the changes by
     // directly writing to the terminal.
     if (input == '\r') {
-      terminal.write('\r\n');
-      terminal.write('\$ ');
+      _outStream.sink.add('\r\n');
+      _outStream.sink.add('\$ ');
     } else if (input.codeUnitAt(0) == 127) {
-      terminal.buffer.eraseCharacters(1);
-      terminal.buffer.backspace();
-      terminal.refresh();
+      // Backspace handling
+      _outStream.sink.add('\b \b');
     } else {
-      terminal.write(input);
+      _outStream.sink.add(input);
     }
   }
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  late TerminalIsolate terminal;
+
+  @override
+  void initState() {
+    super.initState();
+    terminal = TerminalIsolate(
+      backend: FakeTerminalBackend(),
+      maxLines: 10000,
+    );
+    terminal.start();
+  }
+
+  void onInput(String input) {}
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -81,6 +81,11 @@ class FakeTerminalBackend implements TerminalBackend {
   void terminate() {
     //NOOP
   }
+
+  @override
+  void ackProcessed() {
+    //NOOP
+  }
 }
 
 class _MyHomePageState extends State<MyHomePage> {

--- a/example/lib/ssh.dart
+++ b/example/lib/ssh.dart
@@ -98,6 +98,11 @@ class SSHTerminalBackend implements TerminalBackend {
   void terminate() {
     client?.disconnect('terminate');
   }
+
+  @override
+  void ackProcessed() {
+    // NOOP
+  }
 }
 
 class _MyHomePageState extends State<MyHomePage> {

--- a/example/lib/ssh.dart
+++ b/example/lib/ssh.dart
@@ -93,6 +93,11 @@ class SSHTerminalBackend implements TerminalBackend {
   void write(String input) {
     client?.sendChannelData(utf8.encode(input));
   }
+
+  @override
+  void terminate() {
+    client?.disconnect('terminate');
+  }
 }
 
 class _MyHomePageState extends State<MyHomePage> {

--- a/example/lib/ssh.dart
+++ b/example/lib/ssh.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:dartssh/client.dart';
@@ -34,41 +35,75 @@ class MyHomePage extends StatefulWidget {
   _MyHomePageState createState() => _MyHomePageState();
 }
 
-class _MyHomePageState extends State<MyHomePage> {
-  Terminal terminal;
+class SSHTerminalBackend implements TerminalBackend {
   SSHClient client;
 
-  @override
-  void initState() {
-    super.initState();
-    terminal = Terminal(onInput: onInput);
-    connect();
+  String _host;
+  String _username;
+  String _password;
+
+  Completer<int> _exitCodeCompleter;
+  StreamController<String> _outStream;
+
+  SSHTerminalBackend(this._host, this._username, this._password);
+
+  void onWrite(String data) {
+    _outStream.sink.add(data);
   }
 
-  void connect() {
-    terminal.write('connecting $host...');
+  @override
+  Future<int> get exitCode => _exitCodeCompleter.future;
+
+  @override
+  void init() {
+    _exitCodeCompleter = Completer<int>();
+    _outStream = StreamController<String>();
+
+    onWrite('connecting $_host...');
     client = SSHClient(
-      hostport: Uri.parse(host),
-      login: username,
+      hostport: Uri.parse(_host),
+      login: _username,
       print: print,
       termWidth: 80,
       termHeight: 25,
       termvar: 'xterm-256color',
-      getPassword: () => utf8.encode(password),
+      getPassword: () => utf8.encode(_password),
       response: (transport, data) {
-        terminal.write(data);
+        onWrite(data);
       },
       success: () {
-        terminal.write('connected.\n');
+        onWrite('connected.\n');
       },
       disconnected: () {
-        terminal.write('disconnected.');
+        onWrite('disconnected.');
+        _outStream.close();
       },
     );
   }
 
-  void onInput(String input) {
+  @override
+  Stream<String> get out => _outStream.stream;
+
+  @override
+  void resize(int width, int height) {
+    client.setTerminalWindowSize(width, height);
+  }
+
+  @override
+  void write(String input) {
     client?.sendChannelData(utf8.encode(input));
+  }
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  Terminal terminal;
+  SSHTerminalBackend backend;
+
+  @override
+  void initState() {
+    super.initState();
+    backend = SSHTerminalBackend(host, username, password);
+    terminal = Terminal(backend: backend, maxLines: 10000);
   }
 
   @override
@@ -77,9 +112,6 @@ class _MyHomePageState extends State<MyHomePage> {
       body: SafeArea(
         child: TerminalView(
           terminal: terminal,
-          onResize: (width, height) {
-            client?.setTerminalWindowSize(width, height);
-          },
         ),
       ),
     );

--- a/lib/buffer/buffer.dart
+++ b/lib/buffer/buffer.dart
@@ -10,7 +10,10 @@ import 'package:xterm/util/scroll_range.dart';
 import 'package:xterm/util/unicode_v11.dart';
 
 class Buffer {
-  Buffer(this.terminal) {
+  Buffer({
+    required this.terminal,
+    required this.isAltBuffer,
+  }) {
     resetVerticalMargins();
 
     lines = CircularList(
@@ -22,6 +25,7 @@ class Buffer {
   }
 
   final Terminal terminal;
+  final bool isAltBuffer;
   final charset = Charset();
 
   /// lines of the buffer. the length of [lines] should always be equal or
@@ -524,7 +528,7 @@ class Buffer {
     _cursorX = _cursorX.clamp(0, newWidth - 1);
     _cursorY = _cursorY.clamp(0, newHeight - 1);
 
-    if (!terminal.isUsingAltBuffer()) {
+    if (!isAltBuffer) {
       final reflowStrategy = newWidth > oldWidth
           ? ReflowStrategyWider(this)
           : ReflowStrategyNarrower(this);

--- a/lib/buffer/buffer_line.dart
+++ b/lib/buffer/buffer_line.dart
@@ -147,6 +147,9 @@ class BufferLine {
   }
 
   int cellGetContent(int index) {
+    if (index > _maxCols) {
+      return 0;
+    }
     return _cells.getUint32(index * _cellSize + _cellContent);
   }
 

--- a/lib/buffer/buffer_line.dart
+++ b/lib/buffer/buffer_line.dart
@@ -124,8 +124,8 @@ class BufferLine {
   }
 
   void cellClear(int index) {
-    _cells.setInt64(index * _cellSize, 0x00);
-    _cells.setInt64(index * _cellSize + 8, 0x00);
+    _cells.setUint64(index * _cellSize, 0x00);
+    _cells.setUint64(index * _cellSize + 8, 0x00);
   }
 
   void cellInitialize(
@@ -135,11 +135,11 @@ class BufferLine {
     required Cursor cursor,
   }) {
     final cell = index * _cellSize;
-    _cells.setInt32(cell + _cellContent, content);
-    _cells.setInt32(cell + _cellFgColor, cursor.fg);
-    _cells.setInt32(cell + _cellBgColor, cursor.bg);
-    _cells.setInt8(cell + _cellWidth, width);
-    _cells.setInt8(cell + _cellFlags, cursor.flags);
+    _cells.setUint32(cell + _cellContent, content);
+    _cells.setUint32(cell + _cellFgColor, cursor.fg);
+    _cells.setUint32(cell + _cellBgColor, cursor.bg);
+    _cells.setUint8(cell + _cellWidth, width);
+    _cells.setUint8(cell + _cellFlags, cursor.flags);
   }
 
   bool cellHasContent(int index) {
@@ -161,44 +161,44 @@ class BufferLine {
     if (index >= _maxCols) {
       return 0;
     }
-    return _cells.getInt32(index * _cellSize + _cellFgColor);
+    return _cells.getUint32(index * _cellSize + _cellFgColor);
   }
 
   void cellSetFgColor(int index, int color) {
-    _cells.setInt32(index * _cellSize + _cellFgColor, color);
+    _cells.setUint32(index * _cellSize + _cellFgColor, color);
   }
 
   int cellGetBgColor(int index) {
     if (index >= _maxCols) {
       return 0;
     }
-    return _cells.getInt32(index * _cellSize + _cellBgColor);
+    return _cells.getUint32(index * _cellSize + _cellBgColor);
   }
 
   void cellSetBgColor(int index, int color) {
-    _cells.setInt32(index * _cellSize + _cellBgColor, color);
+    _cells.setUint32(index * _cellSize + _cellBgColor, color);
   }
 
   int cellGetFlags(int index) {
     if (index >= _maxCols) {
       return 0;
     }
-    return _cells.getInt8(index * _cellSize + _cellFlags);
+    return _cells.getUint8(index * _cellSize + _cellFlags);
   }
 
   void cellSetFlags(int index, int flags) {
-    _cells.setInt8(index * _cellSize + _cellFlags, flags);
+    _cells.setUint8(index * _cellSize + _cellFlags, flags);
   }
 
   int cellGetWidth(int index) {
     if (index >= _maxCols) {
       return 1;
     }
-    return _cells.getInt8(index * _cellSize + _cellWidth);
+    return _cells.getUint8(index * _cellSize + _cellWidth);
   }
 
   void cellSetWidth(int index, int width) {
-    _cells.setInt8(index * _cellSize + _cellWidth, width);
+    _cells.setUint8(index * _cellSize + _cellWidth, width);
   }
 
   void cellClearFlags(int index) {

--- a/lib/frontend/input_behavior.dart
+++ b/lib/frontend/input_behavior.dart
@@ -9,9 +9,10 @@ abstract class InputBehavior {
 
   TextEditingValue get initEditingState;
 
-  void onKeyStroke(RawKeyEvent event, Terminal terminal);
+  void onKeyStroke(RawKeyEvent event, TerminalUiInteraction terminal);
 
-  TextEditingValue? onTextEdit(TextEditingValue value, Terminal terminal);
+  TextEditingValue? onTextEdit(
+      TextEditingValue value, TerminalUiInteraction terminal);
 
-  void onAction(TextInputAction action, Terminal terminal);
+  void onAction(TextInputAction action, TerminalUiInteraction terminal);
 }

--- a/lib/frontend/input_behavior_default.dart
+++ b/lib/frontend/input_behavior_default.dart
@@ -14,7 +14,7 @@ class InputBehaviorDefault extends InputBehavior {
   TextEditingValue get initEditingState => TextEditingValue.empty;
 
   @override
-  void onKeyStroke(RawKeyEvent event, Terminal terminal) {
+  void onKeyStroke(RawKeyEvent event, TerminalUiInteraction terminal) {
     if (event is! RawKeyDownEvent) {
       return;
     }
@@ -33,8 +33,9 @@ class InputBehaviorDefault extends InputBehavior {
   }
 
   @override
-  TextEditingValue? onTextEdit(TextEditingValue value, Terminal terminal) {
-    terminal.onInput(value.text);
+  TextEditingValue? onTextEdit(
+      TextEditingValue value, TerminalUiInteraction terminal) {
+    terminal.raiseOnInput(value.text);
     if (value == TextEditingValue.empty) {
       return null;
     } else {
@@ -43,7 +44,7 @@ class InputBehaviorDefault extends InputBehavior {
   }
 
   @override
-  void onAction(TextInputAction action, Terminal terminal) {
+  void onAction(TextInputAction action, TerminalUiInteraction terminal) {
     //
   }
 }

--- a/lib/frontend/input_behavior_mobile.dart
+++ b/lib/frontend/input_behavior_mobile.dart
@@ -14,9 +14,10 @@ class InputBehaviorMobile extends InputBehaviorDefault {
     selection: TextSelection.collapsed(offset: 1),
   );
 
-  TextEditingValue onTextEdit(TextEditingValue value, Terminal terminal) {
+  TextEditingValue onTextEdit(
+      TextEditingValue value, TerminalUiInteraction terminal) {
     if (value.text.length > initEditingState.text.length) {
-      terminal.onInput(value.text.substring(1, value.text.length - 1));
+      terminal.raiseOnInput(value.text.substring(1, value.text.length - 1));
     } else if (value.text.length < initEditingState.text.length) {
       terminal.keyInput(TerminalKey.backspace);
     } else {
@@ -30,7 +31,7 @@ class InputBehaviorMobile extends InputBehaviorDefault {
     return initEditingState;
   }
 
-  void onAction(TextInputAction action, Terminal terminal) {
+  void onAction(TextInputAction action, TerminalUiInteraction terminal) {
     print('action $action');
     switch (action) {
       case TextInputAction.done:

--- a/lib/frontend/terminal_view.dart
+++ b/lib/frontend/terminal_view.dart
@@ -21,13 +21,10 @@ import 'package:xterm/theme/terminal_style.dart';
 import 'package:xterm/util/bit_flags.dart';
 import 'package:xterm/util/hash_values.dart';
 
-typedef TerminalResizeHandler = void Function(int width, int height);
-
 class TerminalView extends StatefulWidget {
   TerminalView({
     Key? key,
     required this.terminal,
-    this.onResize,
     this.style = const TerminalStyle(),
     this.opacity = 1.0,
     FocusNode? focusNode,
@@ -40,7 +37,6 @@ class TerminalView extends StatefulWidget {
         super(key: key ?? ValueKey(terminal));
 
   final TerminalUiInteraction terminal;
-  final TerminalResizeHandler? onResize;
   final FocusNode focusNode;
   final bool autofocus;
   final ScrollController scrollController;
@@ -288,7 +284,6 @@ class _TerminalViewState extends State<TerminalView> {
     _lastTerminalWidth = termWidth;
     _lastTerminalHeight = termHeight;
 
-    widget.onResize?.call(termWidth, termHeight);
     widget.terminal.resize(termWidth, termHeight);
   }
 

--- a/lib/frontend/terminal_view.dart
+++ b/lib/frontend/terminal_view.dart
@@ -184,20 +184,23 @@ class _TerminalViewState extends State<TerminalView> {
                 // set viewport height.
                 offset.applyViewportDimension(constraints.maxHeight);
 
-                final minScrollExtent = 0.0;
+                if (widget.terminal.isReady) {
+                  final minScrollExtent = 0.0;
 
-                final maxScrollExtent = math.max(
-                    0.0,
-                    _cellSize.cellHeight * widget.terminal.terminalHeight -
-                        constraints.maxHeight);
+                  final maxScrollExtent = math.max(
+                      0.0,
+                      _cellSize.cellHeight * widget.terminal.bufferHeight -
+                          constraints.maxHeight);
 
-                // set how much the terminal can scroll
-                offset.applyContentDimensions(minScrollExtent, maxScrollExtent);
+                  // set how much the terminal can scroll
+                  offset.applyContentDimensions(
+                      minScrollExtent, maxScrollExtent);
 
-                // syncronize pending terminal scroll extent to ScrollController
-                if (_terminalScrollExtent != null) {
-                  position.correctPixels(_terminalScrollExtent!);
-                  _terminalScrollExtent = null;
+                  // syncronize pending terminal scroll extent to ScrollController
+                  if (_terminalScrollExtent != null) {
+                    position.correctPixels(_terminalScrollExtent!);
+                    _terminalScrollExtent = null;
+                  }
                 }
 
                 return buildTerminal(context);
@@ -272,6 +275,9 @@ class _TerminalViewState extends State<TerminalView> {
   int? _lastTerminalHeight;
 
   void onSize(double width, double height) {
+    if (!widget.terminal.isReady) {
+      return;
+    }
     final termWidth = (width / _cellSize.cellWidth).floor();
     final termHeight = (height / _cellSize.cellHeight).floor();
 
@@ -310,10 +316,7 @@ class _TerminalViewState extends State<TerminalView> {
   void onScroll(double offset) {
     final topOffset = (offset / _cellSize.cellHeight).ceil();
     final bottomOffset = widget.terminal.invisibleHeight - topOffset;
-
-    setState(() {
-      widget.terminal.setScrollOffsetFromBottom(bottomOffset);
-    });
+    widget.terminal.setScrollOffsetFromBottom(bottomOffset);
   }
 }
 
@@ -334,6 +337,9 @@ class TerminalPainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
+    if (!terminal.isReady) {
+      return;
+    }
     _paintBackground(canvas);
 
     // if (oscillator.value) {

--- a/lib/frontend/terminal_view.dart
+++ b/lib/frontend/terminal_view.dart
@@ -531,7 +531,7 @@ class TerminalPainter extends CustomPainter {
   }
 
   void _paintCursor(Canvas canvas) {
-    final screenCursorY = terminal.cursorY + terminal.scrollOffset;
+    final screenCursorY = terminal.cursorY + terminal.scrollOffsetFromBottom;
     if (screenCursorY < 0 || screenCursorY >= terminal.terminalHeight) {
       return;
     }

--- a/lib/frontend/terminal_view.dart
+++ b/lib/frontend/terminal_view.dart
@@ -374,6 +374,11 @@ class TerminalPainter extends CustomPainter {
           continue;
         }
 
+        // when a program reports black as background then it "really" means transparent
+        if (effectBgColor == 0xFF000000) {
+          continue;
+        }
+
         // final cellFlags = line.cellGetFlags(i);
         // final cell = line.getCell(i);
         // final attr = cell.attr;

--- a/lib/mouse/mouse_mode.dart
+++ b/lib/mouse/mouse_mode.dart
@@ -24,12 +24,12 @@ class MouseModeNone extends MouseMode {
 
   @override
   void onPanStart(Terminal terminal, Position offset) {
-    terminal.selection.init(offset);
+    terminal.selection!.init(offset);
   }
 
   @override
   void onPanUpdate(Terminal terminal, Position offset) {
-    terminal.selection.update(offset);
+    terminal.selection!.update(offset);
   }
 }
 

--- a/lib/mouse/mouse_mode.dart
+++ b/lib/mouse/mouse_mode.dart
@@ -49,6 +49,6 @@ class MouseModeX10 extends MouseMode {
     buffer.writeCharCode(btn + 32);
     buffer.writeCharCode(px + 32);
     buffer.writeCharCode(py + 32);
-    terminal.onInput(buffer.toString());
+    terminal.backend?.write(buffer.toString());
   }
 }

--- a/lib/terminal/csi.dart
+++ b/lib/terminal/csi.dart
@@ -306,10 +306,11 @@ void csiDeviceStatusReportHandler(CSI csi, Terminal terminal) {
 
   switch (csi.params[0]) {
     case 5:
-      terminal.onInput("\x1b[0n");
+      terminal.backend?.write("\x1b[0n");
       break;
     case 6: // report cursor position
-      terminal.onInput("\x1b[${terminal.cursorX + 1};${terminal.cursorY + 1}R");
+      terminal.backend
+          ?.write("\x1b[${terminal.cursorX + 1};${terminal.cursorY + 1}R");
       break;
     default:
       terminal.debug
@@ -325,7 +326,7 @@ void csiSendDeviceAttributesHandler(CSI csi, Terminal terminal) {
     response = '>0;0;0';
   }
 
-  terminal.onInput('\x1b[${response}c');
+  terminal.backend?.write('\x1b[${response}c');
 }
 
 void csiCursorUpHandler(CSI csi, Terminal terminal) {

--- a/lib/terminal/terminal.dart
+++ b/lib/terminal/terminal.dart
@@ -203,7 +203,6 @@ class Terminal with Observable implements TerminalUiInteraction {
 
   int get cursorX => buffer.cursorX;
   int get cursorY => buffer.cursorY;
-  int get scrollOffset => buffer.scrollOffsetFromBottom;
 
   void setScrollOffsetFromBottom(int scrollOffset) {
     final oldOffset = _buffer.scrollOffsetFromBottom;

--- a/lib/terminal/terminal.dart
+++ b/lib/terminal/terminal.dart
@@ -220,6 +220,7 @@ class Terminal with Observable implements TerminalUiInteraction {
   void write(String text) {
     _queue.addAll(text.runes);
     _processInput();
+    backend?.ackProcessed();
     refresh();
   }
 

--- a/lib/terminal/terminal.dart
+++ b/lib/terminal/terminal.dart
@@ -44,8 +44,8 @@ class Terminal with Observable implements TerminalUiInteraction {
   }) : _maxLines = maxLines {
     backend?.init();
     backend?.out.listen(write);
-    _mainBuffer = Buffer(this);
-    _altBuffer = Buffer(this);
+    _mainBuffer = Buffer(terminal: this, isAltBuffer: false);
+    _altBuffer = Buffer(terminal: this, isAltBuffer: true);
     _buffer = _mainBuffer;
 
     cursor = Cursor(
@@ -362,7 +362,9 @@ class Terminal with Observable implements TerminalUiInteraction {
     _viewWidth = newWidth;
     _viewHeight = newHeight;
 
-    buffer.resize(oldWidth, oldHeight, newWidth, newHeight);
+    //we need to resize both buffers so that they are ready when we switch between them
+    _altBuffer.resize(oldWidth, oldHeight, newWidth, newHeight);
+    _mainBuffer.resize(oldWidth, oldHeight, newWidth, newHeight);
 
     // maybe reflow should happen here.
     if (buffer == _altBuffer) {

--- a/lib/terminal/terminal.dart
+++ b/lib/terminal/terminal.dart
@@ -196,6 +196,15 @@ class Terminal with Observable {
   int get cursorY => buffer.cursorY;
   int get scrollOffset => buffer.scrollOffsetFromBottom;
 
+  void setScrollOffsetFromBottom(int scrollOffset) {
+    final oldOffset = _buffer.scrollOffsetFromBottom;
+    _buffer.setScrollOffsetFromBottom(scrollOffset);
+    if (oldOffset != scrollOffset) {
+      _dirty = true;
+      refresh();
+    }
+  }
+
   /// Writes data to the terminal. Terminal sequences and special characters are
   /// interpreted.
   ///

--- a/lib/terminal/terminal_backend.dart
+++ b/lib/terminal/terminal_backend.dart
@@ -6,4 +6,6 @@ abstract class TerminalBackend {
 
   void write(String input);
   void resize(int width, int height);
+
+  void terminate();
 }

--- a/lib/terminal/terminal_backend.dart
+++ b/lib/terminal/terminal_backend.dart
@@ -1,11 +1,28 @@
+import 'package:xterm/terminal/terminal_isolate.dart';
+
+/// interface for every Terminal backend
 abstract class TerminalBackend {
+  /// initializes the backend
+  /// This can be used to instantiate instances that are problematic when
+  /// passed to a Isolate.
+  /// The [TerminalIsolate] will pass the backend to the [Terminal] that then
+  /// executes [init] from inside the Isolate.
+  /// So when your backend needs any complex instances (most of them will)
+  /// then strongly consider instantiating them here
   void init();
 
+  /// Stream for data that gets read from the backend
   Stream<String> get out;
+
+  /// Future that fires when the backend terminates
   Future<int> get exitCode;
 
+  /// writes data to this backend
   void write(String input);
+
+  /// notifies the backend about a view port resize that happened
   void resize(int width, int height);
 
+  /// terminates this backend
   void terminate();
 }

--- a/lib/terminal/terminal_backend.dart
+++ b/lib/terminal/terminal_backend.dart
@@ -25,4 +25,7 @@ abstract class TerminalBackend {
 
   /// terminates this backend
   void terminate();
+
+  /// acknowledges processing of a data junk
+  void ackProcessed();
 }

--- a/lib/terminal/terminal_backend.dart
+++ b/lib/terminal/terminal_backend.dart
@@ -1,0 +1,9 @@
+abstract class TerminalBackend {
+  void init();
+
+  Stream<String> get out;
+  Future<int> get exitCode;
+
+  void write(String input);
+  void resize(int width, int height);
+}

--- a/lib/terminal/terminal_isolate.dart
+++ b/lib/terminal/terminal_isolate.dart
@@ -45,6 +45,7 @@ void terminalMain(SendPort port) async {
   port.send(rp.sendPort);
 
   Terminal? _terminal;
+  var _needNotify = true;
 
   await for (var msg in rp) {
     final _IsolateCommand action = msg[0];
@@ -69,7 +70,10 @@ void terminalMain(SendPort port) async {
             theme: initData.theme,
             maxLines: initData.maxLines);
         _terminal.addListener(() {
-          port.send([_IsolateEvent.NotifyChange]);
+          if (_needNotify) {
+            port.send([_IsolateEvent.NotifyChange]);
+            _needNotify = false;
+          }
         });
         initData.backend?.exitCode
             .then((value) => port.send([_IsolateEvent.Exit, value]));
@@ -131,6 +135,7 @@ void terminalMain(SendPort port) async {
               _terminal.getVisibleLines(),
               _terminal.scrollOffset);
           port.send([_IsolateEvent.NewState, newState]);
+          _needNotify = true;
         }
         break;
       case _IsolateCommand.Paste:

--- a/lib/terminal/terminal_isolate.dart
+++ b/lib/terminal/terminal_isolate.dart
@@ -337,7 +337,7 @@ class TerminalIsolate with Observable implements TerminalUiInteraction {
   @override
   bool get isReady => _lastState != null;
 
-  void start() async {
+  Future<void> start() async {
     final initialRefreshCompleted = Completer<bool>();
     var firstReceivePort = ReceivePort();
     _isolate = await Isolate.spawn(terminalMain, firstReceivePort.sendPort);

--- a/lib/terminal/terminal_isolate.dart
+++ b/lib/terminal/terminal_isolate.dart
@@ -1,0 +1,443 @@
+import 'dart:isolate';
+
+import 'package:xterm/buffer/buffer_line.dart';
+import 'package:xterm/input/keys.dart';
+import 'package:xterm/mouse/position.dart';
+import 'package:xterm/mouse/selection.dart';
+import 'package:xterm/terminal/platform.dart';
+import 'package:xterm/terminal/terminal.dart';
+import 'package:xterm/terminal/terminal_ui_interaction.dart';
+import 'package:xterm/theme/terminal_color.dart';
+import 'package:xterm/theme/terminal_theme.dart';
+import 'package:xterm/theme/terminal_themes.dart';
+import 'package:xterm/util/observable.dart';
+
+void terminalMain(SendPort port) async {
+  final rp = ReceivePort();
+  port.send(rp.sendPort);
+
+  Terminal? _terminal;
+
+  await for (var msg in rp) {
+    final String action = msg[0];
+    switch (action) {
+      case 'sendPort':
+        port = msg[1];
+        break;
+      case 'init':
+        final TerminalInitData initData = msg[1];
+        _terminal = Terminal(
+            onInput: (String input) {
+              port.send(['onInput', input]);
+            },
+            onTitleChange: (String title) {
+              port.send(['onTitleChange', title]);
+            },
+            onIconChange: (String icon) {
+              port.send(['onIconChange', icon]);
+            },
+            onBell: () {
+              port.send(['onBell']);
+            },
+            platform: initData.platform,
+            theme: initData.theme,
+            maxLines: initData.maxLines);
+        _terminal.addListener(() {
+          port.send(['notify']);
+        });
+        break;
+      case 'write':
+        if (_terminal == null) {
+          break;
+        }
+        _terminal.write(msg[1]);
+        break;
+      case 'refresh':
+        if (_terminal == null) {
+          break;
+        }
+
+        _terminal.refresh();
+        break;
+      case 'selection.clear':
+        if (_terminal == null) {
+          break;
+        }
+        _terminal.selection.clear();
+        break;
+      case 'mouseMode.onTap':
+        if (_terminal == null) {
+          break;
+        }
+        _terminal.mouseMode.onTap(_terminal, msg[1]);
+        break;
+      case 'mouseMode.onPanStart':
+        if (_terminal == null) {
+          break;
+        }
+        _terminal.mouseMode.onPanStart(_terminal, msg[1]);
+        break;
+      case 'mouseMode.onPanUpdate':
+        if (_terminal == null) {
+          break;
+        }
+        _terminal.mouseMode.onPanUpdate(_terminal, msg[1]);
+        break;
+      case 'setScrollOffsetFromBottom':
+        if (_terminal == null) {
+          break;
+        }
+        _terminal.buffer.setScrollOffsetFromBottom(msg[1]);
+        break;
+      case 'resize':
+        if (_terminal == null) {
+          break;
+        }
+        _terminal.resize(msg[1], msg[2]);
+        break;
+      case 'setScrollOffsetFromBottom':
+        if (_terminal == null) {
+          break;
+        }
+        _terminal.buffer.setScrollOffsetFromBottom(msg[1]);
+        break;
+      case 'keyInput':
+        if (_terminal == null) {
+          break;
+        }
+        _terminal.keyInput(msg[1],
+            ctrl: msg[2], alt: msg[3], shift: msg[4], mac: msg[5]);
+        break;
+      case 'requestNewStateWhenDirty':
+        if (_terminal == null) {
+          break;
+        }
+        if (_terminal.dirty) {
+          final newState = TerminalState(
+              _terminal.buffer.scrollOffsetFromBottom,
+              _terminal.buffer.scrollOffsetFromTop,
+              _terminal.buffer.height,
+              _terminal.invisibleHeight,
+              _terminal.viewHeight,
+              _terminal.viewWidth,
+              _terminal.selection,
+              _terminal.getSelectedText(),
+              _terminal.theme.background,
+              _terminal.cursorX,
+              _terminal.cursorY,
+              _terminal.showCursor,
+              _terminal.theme.cursor,
+              _terminal.getVisibleLines(),
+              _terminal.scrollOffset);
+          port.send(['newState', newState]);
+        }
+        break;
+      case 'paste':
+        if (_terminal == null) {
+          break;
+        }
+        _terminal.paste(msg[1]);
+        break;
+    }
+  }
+}
+
+class TerminalInitData {
+  PlatformBehavior platform;
+  TerminalTheme theme;
+  int maxLines;
+
+  TerminalInitData(this.platform, this.theme, this.maxLines);
+}
+
+class TerminalState {
+  int scrollOffsetFromTop;
+  int scrollOffsetFromBottom;
+
+  int bufferHeight;
+  int invisibleHeight;
+
+  int viewHeight;
+  int viewWidth;
+
+  Selection selection;
+  String? selectedText;
+
+  int backgroundColor;
+
+  int cursorX;
+  int cursorY;
+  bool showCursor;
+  int cursorColor;
+
+  List<BufferLine> visibleLines;
+
+  int scrollOffset;
+
+  bool consumed = false;
+
+  TerminalState(
+      this.scrollOffsetFromBottom,
+      this.scrollOffsetFromTop,
+      this.bufferHeight,
+      this.invisibleHeight,
+      this.viewHeight,
+      this.viewWidth,
+      this.selection,
+      this.selectedText,
+      this.backgroundColor,
+      this.cursorX,
+      this.cursorY,
+      this.showCursor,
+      this.cursorColor,
+      this.visibleLines,
+      this.scrollOffset);
+}
+
+void _defaultInputHandler(String _) {}
+void _defaultBellHandler() {}
+void _defaultTitleHandler(String _) {}
+void _defaultIconHandler(String _) {}
+
+class TerminalIsolate with Observable implements TerminalUiInteraction {
+  final _receivePort = ReceivePort();
+  SendPort? _sendPort;
+  late Isolate _isolate;
+
+  final TerminalInputHandler onInput;
+  final BellHandler onBell;
+  final TitleChangeHandler onTitleChange;
+  final IconChangeHandler onIconChange;
+  final PlatformBehavior _platform;
+
+  final TerminalTheme theme;
+  final int maxLines;
+
+  TerminalState? _lastState;
+
+  TerminalState? get lastState {
+    return _lastState;
+  }
+
+  TerminalIsolate(
+      {this.onInput = _defaultInputHandler,
+      this.onBell = _defaultBellHandler,
+      this.onTitleChange = _defaultTitleHandler,
+      this.onIconChange = _defaultIconHandler,
+      PlatformBehavior platform = PlatformBehaviors.unix,
+      this.theme = TerminalThemes.defaultTheme,
+      required this.maxLines})
+      : _platform = platform;
+
+  @override
+  int get scrollOffsetFromBottom => _lastState?.scrollOffsetFromBottom ?? 0;
+
+  @override
+  int get scrollOffsetFromTop => _lastState?.scrollOffsetFromTop ?? 0;
+
+  @override
+  int get scrollOffset => _lastState?.scrollOffset ?? 0;
+
+  @override
+  int get bufferHeight => _lastState?.bufferHeight ?? 0;
+
+  @override
+  int get terminalHeight => _lastState?.viewHeight ?? 0;
+
+  @override
+  int get terminalWidth => _lastState?.viewWidth ?? 0;
+
+  @override
+  int get invisibleHeight => _lastState?.invisibleHeight ?? 0;
+
+  @override
+  Selection? get selection => _lastState?.selection;
+
+  @override
+  bool get showCursor => _lastState?.showCursor ?? true;
+
+  @override
+  List<BufferLine> getVisibleLines() {
+    if (_lastState == null) {
+      return List<BufferLine>.empty();
+    }
+    return _lastState!.visibleLines;
+  }
+
+  @override
+  int get cursorY => _lastState?.cursorY ?? 0;
+
+  @override
+  int get cursorX => _lastState?.cursorX ?? 0;
+
+  @override
+  BufferLine? get currentLine {
+    if (_lastState == null) {
+      return null;
+    }
+
+    int visibleLineIndex =
+        _lastState!.cursorY - _lastState!.scrollOffsetFromTop;
+    if (visibleLineIndex < 0) {
+      visibleLineIndex = _lastState!.cursorY;
+    }
+    return _lastState!.visibleLines[visibleLineIndex];
+  }
+
+  @override
+  int get cursorColor => _lastState?.cursorColor ?? 0;
+
+  @override
+  int get backgroundColor => _lastState?.backgroundColor ?? 0;
+
+  @override
+  bool get dirty {
+    if (_lastState == null) {
+      return false;
+    }
+    if (_lastState!.consumed) {
+      return false;
+    }
+    _lastState!.consumed = true;
+    return true;
+  }
+
+  @override
+  PlatformBehavior get platform => _platform;
+
+  void start() async {
+    var firstReceivePort = ReceivePort();
+    _isolate = await Isolate.spawn(terminalMain, firstReceivePort.sendPort);
+    _sendPort = await firstReceivePort.first;
+    _sendPort!.send(['sendPort', _receivePort.sendPort]);
+    _receivePort.listen((message) {
+      String action = message[0];
+      switch (action) {
+        case 'onInput':
+          this.onInput(message[1]);
+          break;
+        case 'onBell':
+          this.onBell();
+          break;
+        case 'onTitleChange':
+          this.onTitleChange(message[1]);
+          break;
+        case 'onIconChange':
+          this.onIconChange(message[1]);
+          break;
+        case 'notify':
+          poll();
+          break;
+        case 'newState':
+          _lastState = message[1];
+          this.notifyListeners();
+          break;
+      }
+    });
+    _sendPort!.send(
+        ['init', TerminalInitData(this.platform, this.theme, this.maxLines)]);
+  }
+
+  void stop() {
+    _isolate.kill();
+  }
+
+  void poll() {
+    if (_sendPort == null) {
+      return;
+    }
+    _sendPort!.send(['requestNewStateWhenDirty']);
+  }
+
+  void refresh() {
+    if (_sendPort == null) {
+      return;
+    }
+    _sendPort!.send(['refresh']);
+  }
+
+  void clearSelection() {
+    if (_sendPort == null) {
+      return;
+    }
+    _sendPort!.send(['clearSelection']);
+  }
+
+  void onMouseTap(Position position) {
+    if (_sendPort == null) {
+      return;
+    }
+    _sendPort!.send(['mouseMode.onTap', position]);
+  }
+
+  void onPanStart(Position position) {
+    if (_sendPort == null) {
+      return;
+    }
+    _sendPort!.send(['mouseMode.onPanStart', position]);
+  }
+
+  void onPanUpdate(Position position) {
+    if (_sendPort == null) {
+      return;
+    }
+    _sendPort!.send(['mouseMode.onPanUpdate', position]);
+  }
+
+  void setScrollOffsetFromBottom(int offset) {
+    if (_sendPort == null) {
+      return;
+    }
+    _sendPort!.send(['setScrollOffsetFromBottom', offset]);
+  }
+
+  int convertViewLineToRawLine(int viewLine) {
+    if (_lastState == null) {
+      return 0;
+    }
+    if (_lastState!.viewHeight > _lastState!.bufferHeight) {
+      return viewLine;
+    }
+
+    return viewLine + (_lastState!.bufferHeight - _lastState!.viewHeight);
+  }
+
+  void write(String text) {
+    if (_sendPort == null) {
+      return;
+    }
+    _sendPort!.send(['write', text]);
+  }
+
+  void paste(String data) {
+    if (_sendPort == null) {
+      return;
+    }
+    _sendPort!.send(['paste', data]);
+  }
+
+  void resize(int newWidth, int newHeight) {
+    if (_sendPort == null) {
+      return;
+    }
+    _sendPort!.send(['resize', newWidth, newHeight]);
+  }
+
+  void raiseOnInput(String text) {
+    onInput(text);
+  }
+
+  void keyInput(
+    TerminalKey key, {
+    bool ctrl = false,
+    bool alt = false,
+    bool shift = false,
+    bool mac = false,
+    // bool meta,
+  }) {
+    if (_sendPort == null) {
+      return;
+    }
+    _sendPort!.send(['keyInput', key, ctrl, alt, shift, mac]);
+  }
+}

--- a/lib/terminal/terminal_isolate.dart
+++ b/lib/terminal/terminal_isolate.dart
@@ -119,21 +119,22 @@ void terminalMain(SendPort port) async {
         }
         if (_terminal.dirty) {
           final newState = TerminalState(
-              _terminal.buffer.scrollOffsetFromBottom,
-              _terminal.buffer.scrollOffsetFromTop,
-              _terminal.buffer.height,
-              _terminal.invisibleHeight,
-              _terminal.viewHeight,
-              _terminal.viewWidth,
-              _terminal.selection!,
-              _terminal.getSelectedText(),
-              _terminal.theme.background,
-              _terminal.cursorX,
-              _terminal.cursorY,
-              _terminal.showCursor,
-              _terminal.theme.cursor,
-              _terminal.getVisibleLines(),
-              _terminal.scrollOffset);
+            _terminal.buffer.scrollOffsetFromBottom,
+            _terminal.buffer.scrollOffsetFromTop,
+            _terminal.buffer.height,
+            _terminal.invisibleHeight,
+            _terminal.viewHeight,
+            _terminal.viewWidth,
+            _terminal.selection!,
+            _terminal.getSelectedText(),
+            _terminal.theme.background,
+            _terminal.cursorX,
+            _terminal.cursorY,
+            _terminal.showCursor,
+            _terminal.theme.cursor,
+            _terminal.getVisibleLines(),
+            _terminal.scrollOffset,
+          );
           port.send([_IsolateEvent.NewState, newState]);
           _needNotify = true;
         }
@@ -183,21 +184,22 @@ class TerminalState {
   bool consumed = false;
 
   TerminalState(
-      this.scrollOffsetFromBottom,
-      this.scrollOffsetFromTop,
-      this.bufferHeight,
-      this.invisibleHeight,
-      this.viewHeight,
-      this.viewWidth,
-      this.selection,
-      this.selectedText,
-      this.backgroundColor,
-      this.cursorX,
-      this.cursorY,
-      this.showCursor,
-      this.cursorColor,
-      this.visibleLines,
-      this.scrollOffset);
+    this.scrollOffsetFromBottom,
+    this.scrollOffsetFromTop,
+    this.bufferHeight,
+    this.invisibleHeight,
+    this.viewHeight,
+    this.viewWidth,
+    this.selection,
+    this.selectedText,
+    this.backgroundColor,
+    this.cursorX,
+    this.cursorY,
+    this.showCursor,
+    this.cursorColor,
+    this.visibleLines,
+    this.scrollOffset,
+  );
 }
 
 void _defaultBellHandler() {}
@@ -229,16 +231,16 @@ class TerminalIsolate with Observable implements TerminalUiInteraction {
     return _lastState;
   }
 
-  TerminalIsolate(
-      {this.backend,
-      this.onBell = _defaultBellHandler,
-      this.onTitleChange = _defaultTitleHandler,
-      this.onIconChange = _defaultIconHandler,
-      PlatformBehavior platform = PlatformBehaviors.unix,
-      this.theme = TerminalThemes.defaultTheme,
-      this.minRefreshDelay = const Duration(milliseconds: 16),
-      required this.maxLines})
-      : _platform = platform,
+  TerminalIsolate({
+    this.backend,
+    this.onBell = _defaultBellHandler,
+    this.onTitleChange = _defaultTitleHandler,
+    this.onIconChange = _defaultIconHandler,
+    PlatformBehavior platform = PlatformBehaviors.unix,
+    this.theme = TerminalThemes.defaultTheme,
+    this.minRefreshDelay = const Duration(milliseconds: 16),
+    required this.maxLines,
+  })   : _platform = platform,
         _refreshEventDebouncer = EventDebouncer(minRefreshDelay);
 
   @override

--- a/lib/terminal/terminal_isolate.dart
+++ b/lib/terminal/terminal_isolate.dart
@@ -54,7 +54,7 @@ void terminalMain(SendPort port) async {
         _terminal?.refresh();
         break;
       case 'selection.clear':
-        _terminal?.selection.clear();
+        _terminal?.selection!.clear();
         break;
       case 'mouseMode.onTap':
         _terminal?.mouseMode.onTap(_terminal, msg[1]);
@@ -93,7 +93,7 @@ void terminalMain(SendPort port) async {
               _terminal.invisibleHeight,
               _terminal.viewHeight,
               _terminal.viewWidth,
-              _terminal.selection,
+              _terminal.selection!,
               _terminal.getSelectedText(),
               _terminal.theme.background,
               _terminal.cursorX,
@@ -167,7 +167,6 @@ class TerminalState {
       this.scrollOffset);
 }
 
-void _defaultInputHandler(String _) {}
 void _defaultBellHandler() {}
 void _defaultTitleHandler(String _) {}
 void _defaultIconHandler(String _) {}

--- a/lib/terminal/terminal_isolate.dart
+++ b/lib/terminal/terminal_isolate.dart
@@ -369,58 +369,38 @@ class TerminalIsolate with Observable implements TerminalUiInteraction {
   }
 
   void poll() {
-    if (_sendPort == null) {
-      return;
-    }
-    _sendPort!.send([_IsolateCommand.requestNewStateWhenDirty]);
+    _sendPort?.send([_IsolateCommand.requestNewStateWhenDirty]);
   }
 
   void refresh() {
-    if (_sendPort == null) {
-      return;
-    }
-    _sendPort!.send([_IsolateCommand.refresh]);
+    _sendPort?.send([_IsolateCommand.refresh]);
   }
 
   void clearSelection() {
-    if (_sendPort == null) {
-      return;
-    }
-    _sendPort!.send([_IsolateCommand.clearSelection]);
+    _sendPort?.send([_IsolateCommand.clearSelection]);
   }
 
   void onMouseTap(Position position) {
-    if (_sendPort == null) {
-      return;
-    }
-    _sendPort!.send([_IsolateCommand.mouseTap, position]);
+    _sendPort?.send([_IsolateCommand.mouseTap, position]);
   }
 
   void onPanStart(Position position) {
-    if (_sendPort == null) {
-      return;
-    }
-    _sendPort!.send([_IsolateCommand.mousePanStart, position]);
+    _sendPort?.send([_IsolateCommand.mousePanStart, position]);
   }
 
   void onPanUpdate(Position position) {
-    if (_sendPort == null) {
-      return;
-    }
-    _sendPort!.send([_IsolateCommand.mousePanUpdate, position]);
+    _sendPort?.send([_IsolateCommand.mousePanUpdate, position]);
   }
 
   void setScrollOffsetFromBottom(int offset) {
-    if (_sendPort == null) {
-      return;
-    }
-    _sendPort!.send([_IsolateCommand.setScrollOffsetFromTop, offset]);
+    _sendPort?.send([_IsolateCommand.setScrollOffsetFromTop, offset]);
   }
 
   int convertViewLineToRawLine(int viewLine) {
     if (_lastState == null) {
       return 0;
     }
+
     if (_lastState!.viewHeight > _lastState!.bufferHeight) {
       return viewLine;
     }
@@ -429,24 +409,15 @@ class TerminalIsolate with Observable implements TerminalUiInteraction {
   }
 
   void write(String text) {
-    if (_sendPort == null) {
-      return;
-    }
-    _sendPort!.send([_IsolateCommand.write, text]);
+    _sendPort?.send([_IsolateCommand.write, text]);
   }
 
   void paste(String data) {
-    if (_sendPort == null) {
-      return;
-    }
-    _sendPort!.send([_IsolateCommand.paste, data]);
+    _sendPort?.send([_IsolateCommand.paste, data]);
   }
 
   void resize(int newWidth, int newHeight) {
-    if (_sendPort == null) {
-      return;
-    }
-    _sendPort!.send([_IsolateCommand.resize, newWidth, newHeight]);
+    _sendPort?.send([_IsolateCommand.resize, newWidth, newHeight]);
   }
 
   void raiseOnInput(String text) {
@@ -461,9 +432,6 @@ class TerminalIsolate with Observable implements TerminalUiInteraction {
     bool mac = false,
     // bool meta,
   }) {
-    if (_sendPort == null) {
-      return;
-    }
-    _sendPort!.send([_IsolateCommand.keyInput, key, ctrl, alt, shift, mac]);
+    _sendPort?.send([_IsolateCommand.keyInput, key, ctrl, alt, shift, mac]);
   }
 }

--- a/lib/terminal/terminal_isolate.dart
+++ b/lib/terminal/terminal_isolate.dart
@@ -342,6 +342,7 @@ class TerminalIsolate with Observable implements TerminalUiInteraction {
     var firstReceivePort = ReceivePort();
     _isolate = await Isolate.spawn(terminalMain, firstReceivePort.sendPort);
     _sendPort = await firstReceivePort.first;
+    firstReceivePort.close();
     _sendPort!.send([_IsolateCommand.sendPort, _receivePort.sendPort]);
     _receivePort.listen((message) {
       _IsolateEvent action = message[0];

--- a/lib/terminal/terminal_ui_interaction.dart
+++ b/lib/terminal/terminal_ui_interaction.dart
@@ -24,6 +24,8 @@ abstract class TerminalUiInteraction with Observable {
   bool get dirty;
   PlatformBehavior get platform;
 
+  bool get isReady;
+
   void refresh();
   void clearSelection();
   void onMouseTap(Position position);

--- a/lib/terminal/terminal_ui_interaction.dart
+++ b/lib/terminal/terminal_ui_interaction.dart
@@ -1,0 +1,46 @@
+import 'package:xterm/buffer/buffer_line.dart';
+import 'package:xterm/input/keys.dart';
+import 'package:xterm/mouse/position.dart';
+import 'package:xterm/mouse/selection.dart';
+import 'package:xterm/terminal/platform.dart';
+import 'package:xterm/util/observable.dart';
+
+abstract class TerminalUiInteraction with Observable {
+  int get scrollOffsetFromBottom;
+  int get scrollOffsetFromTop;
+  int get scrollOffset;
+  int get bufferHeight;
+  int get terminalHeight;
+  int get terminalWidth;
+  int get invisibleHeight;
+  Selection? get selection;
+  bool get showCursor;
+  List<BufferLine> getVisibleLines();
+  int get cursorY;
+  int get cursorX;
+  BufferLine? get currentLine;
+  int get cursorColor;
+  int get backgroundColor;
+  bool get dirty;
+  PlatformBehavior get platform;
+
+  void refresh();
+  void clearSelection();
+  void onMouseTap(Position position);
+  void onPanStart(Position position);
+  void onPanUpdate(Position position);
+  void setScrollOffsetFromBottom(int offset);
+  int convertViewLineToRawLine(int viewLine);
+  void raiseOnInput(String input);
+  void write(String text);
+  void paste(String data);
+  void resize(int newWidth, int newHeight);
+  void keyInput(
+    TerminalKey key, {
+    bool ctrl = false,
+    bool alt = false,
+    bool shift = false,
+    bool mac = false,
+    // bool meta,
+  });
+}

--- a/lib/terminal/terminal_ui_interaction.dart
+++ b/lib/terminal/terminal_ui_interaction.dart
@@ -23,6 +23,7 @@ abstract class TerminalUiInteraction with Observable {
   int get backgroundColor;
   bool get dirty;
   PlatformBehavior get platform;
+  String? get selectedText;
 
   bool get isReady;
 
@@ -45,4 +46,8 @@ abstract class TerminalUiInteraction with Observable {
     bool mac = false,
     // bool meta,
   });
+
+  Future<int> get backendExited;
+  void terminateBackend();
+  bool get isTerminated;
 }

--- a/lib/terminal/terminal_ui_interaction.dart
+++ b/lib/terminal/terminal_ui_interaction.dart
@@ -5,39 +5,99 @@ import 'package:xterm/mouse/selection.dart';
 import 'package:xterm/terminal/platform.dart';
 import 'package:xterm/util/observable.dart';
 
+/// this interface describes what a Terminal UI needs from a Terminal
 abstract class TerminalUiInteraction with Observable {
+  /// the ViewPort scroll offset from the bottom
   int get scrollOffsetFromBottom;
+
+  /// the ViewPort scroll offset from the top
   int get scrollOffsetFromTop;
-  int get scrollOffset;
+
+  /// the total buffer height
   int get bufferHeight;
+
+  /// terminal height (view port)
   int get terminalHeight;
+
+  /// terminal width (view port)
   int get terminalWidth;
+
+  /// the part of the buffer that is not visible (scrollback)
   int get invisibleHeight;
+
+  /// object that describes details about the current selection
   Selection? get selection;
+
+  /// [true] when the cursor shall be shown, otherwise [false]
   bool get showCursor;
+
+  /// returns the visible lines
   List<BufferLine> getVisibleLines();
+
+  /// cursor y coordinate
   int get cursorY;
+
+  /// cursor x coordinate
   int get cursorX;
+
+  /// current line
   BufferLine? get currentLine;
+
+  /// color code for the cursor
   int get cursorColor;
+
+  /// color code for the background
   int get backgroundColor;
+
+  /// flag that indicates if the terminal is dirty (since the last time this
+  /// flag has been queried)
   bool get dirty;
+
+  /// platform behavior for this terminal
   PlatformBehavior get platform;
+
+  /// selected text defined by [selection]
   String? get selectedText;
 
+  /// flag that indicates if the Terminal is ready
   bool get isReady;
 
+  /// refreshes the Terminal (notifies listeners and sets it to dirty)
   void refresh();
+
+  /// clears the selection
   void clearSelection();
+
+  /// notify the Terminal about a mouse tap
   void onMouseTap(Position position);
+
+  /// notify the Terminal about a pan start
   void onPanStart(Position position);
+
+  /// notify the Terminal about a pan update
   void onPanUpdate(Position position);
+
+  /// sets the scroll offset from bottom (scrolling)
   void setScrollOffsetFromBottom(int offset);
+
+  /// converts the given view line (view port line) index to its position in the
+  /// overall buffer
   int convertViewLineToRawLine(int viewLine);
+
+  /// notifies the Terminal about user input
   void raiseOnInput(String input);
+
+  /// writes data to the Terminal
   void write(String text);
+
+  /// paste clipboard content to the Terminal
   void paste(String data);
+
+  /// notifies the Terminal about a resize that happened. The Terminal will
+  /// do any resize / reflow logic and notify the backend about the resize
   void resize(int newWidth, int newHeight);
+
+  /// notifies the Terminal about key input
   void keyInput(
     TerminalKey key, {
     bool ctrl = false,
@@ -47,7 +107,12 @@ abstract class TerminalUiInteraction with Observable {
     // bool meta,
   });
 
+  /// Future that fires when the backend has exited
   Future<int> get backendExited;
+
+  /// terminates the backend. If already terminated, nothing happens
   void terminateBackend();
+
+  /// flag that indicates if the backend is already terminated
   bool get isTerminated;
 }

--- a/lib/util/event_debouncer.dart
+++ b/lib/util/event_debouncer.dart
@@ -1,0 +1,39 @@
+import 'dart:async';
+
+/// EventDebouncer makes sure that events aren't fired at a higher frequency
+/// than specified.
+/// To ensure that EventDebouncer will ignore events that happen in between
+/// and just call the latest event that happened.
+class EventDebouncer {
+  final Duration _debounceDuration;
+  Timer? _debounceTimer;
+  Function? _latestCallback;
+
+  EventDebouncer(this._debounceDuration);
+
+  void _consumeLatestCallback() {
+    if (!(_debounceTimer?.isActive ?? false)) {
+      _debounceTimer = null;
+    }
+
+    if (_latestCallback == null) {
+      return;
+    }
+
+    if (_debounceTimer == null) {
+      _latestCallback!();
+      _latestCallback = null;
+      _debounceTimer = Timer(
+        _debounceDuration,
+        () {
+          _consumeLatestCallback();
+        },
+      );
+    }
+  }
+
+  void notifyEvent(Function callback) {
+    _latestCallback = callback;
+    _consumeLatestCallback();
+  }
+}

--- a/lib/xterm.dart
+++ b/lib/xterm.dart
@@ -1,5 +1,6 @@
 library xterm;
 
 export 'terminal/terminal_isolate.dart';
+export 'terminal/terminal_backend.dart';
 export 'terminal/terminal_ui_interaction.dart';
 export 'terminal/platform.dart';

--- a/lib/xterm.dart
+++ b/lib/xterm.dart
@@ -1,4 +1,5 @@
 library xterm;
 
-export 'terminal/terminal.dart';
+export 'terminal/terminal_isolate.dart';
+export 'terminal/terminal_ui_interaction.dart';
 export 'terminal/platform.dart';

--- a/lib/xterm.dart
+++ b/lib/xterm.dart
@@ -1,5 +1,6 @@
 library xterm;
 
+export 'terminal/terminal.dart';
 export 'terminal/terminal_isolate.dart';
 export 'terminal/terminal_backend.dart';
 export 'terminal/terminal_ui_interaction.dart';


### PR DESCRIPTION
This PR wants to move the terminal logic and the file I/O with the pty into a separate Isolate.

The reason for this is that this way we can better scale to have multiple terminal instances that might get slower in processing data when the machine gets near its limit but doesn't slow down the UI Isolate.

There are a couple of decisions to make, big and small. This PR already did some of them but I as this is WIP currently everything can (and should) be discussed.

**1. Pty connection**
The challenge here was to have the backend of the terminal configurable and also have it being executed in the terminal Isolate.
The approach I have chosen is to introduce a TerminalBackend interface. The instance of this interface given to the TerminalIsolate is passed into the Terminal Isolate.
This only works when there are no closures in the backend instance at the time of passing. I achieved this by doing a late initialization when the backend has been passed already.
The problem here is that this introduces a complexity to the user (as this is the place where currently the backend has to be implemented. There pty and xterm come together) that we might not want to have there. It leaks the Isolate complexity to the user.
I sadly don't have a better idea than this or making the concrete possible backends known in the xterm project (much less flexibility)
- [x] currently no better option available

**2. Terminal isolate data exchange**
I have a branch that does the ffi-heap trick but my tests have shown that this doesn't really improve the performance much so that I decided that the PR uses the "plain" Dart approach.
As we already have a ByteData per line that contains all the data as state that has to be copied the only advantage the manual ffi-heap approach would bring that we can control exactly the number of bytes copied (use trimmed length as an indicator)
I think this is something that should be discussed. The branch that contains the ffi approach can be found here:
https://github.com/devmil/xterm.dart/tree/async-io-and-terminal-logic-ffi-data
- [x] Non-ffi approach is used

**3. Pty kind**
We have currently two kinds of pty: blocking and polling. Both don't really fit this use case:
Blocking creates its own isolate and doesn't lead to throttling down when the machine comes to its limit as the isolate is fetching new data regardless if the data transfer events towards the terminal isolate pile up => no throttling
The polling ffi is currently using a timer to trigger the polling. This timer has been set to 15ms which can be quite long (e.g. for `cmatrix -r`). ~~I reduced it to 1ms to improve the experience. This approach leads to throttling as the data fetching happens in the same Isolate as the file reading.~~

I modified the blocking pty to have a channel to signal that a data package has been processed. This can be used to have the pty isolate throttle to the amount of data that currently can be processed.

I also modified the polling pty to adapt the polling frequency to the load that is processed. It goes down to 0,2ms sleep when a huge amount of data is processed and goes back up to 100ms (stepwise) when there is no data. This is a compromise between having high data loads (like `cmatrix -r`) and idle CPU usage.

As the blocking approach currently has a problem that leads to an UI freeze at roughly 4 open tabs I decided to use the adapted polling pty until the problem is solved (problem already exists on master)

- [x] blocking pty now fits as it throttles with the consumer performance
- [x] polling pty fits better because it now scales the polling speed with the amount of data that is processed
- [x] until we have fixed the blocking pty problem (UI freeze) we use the polling pty

**4. Pty communication**
I decided to route any pty communication via the terminal. There was no real other option as we don't have access to the pty when it runs in a separate isolate.
So given the TerminalBackend interface the Terminal does route data writes and resize events to the backend and it is also responsible for watching the exitCode Future.
The Terminal registers itself with the out stream of the backend.
The only thing the user has to do is to pass the backend to the Terminal. There rest happens automatically.

**5. Choice**
I think we should export the Terminal and the TerminalIsolate even if it makes the API more complex.
There will be use cases that need the Terminal directly because they might want to more deeply interact with the backend (like the SSH example) whereas the direct pty connection should be capable of processing data as much as possible without making the UI sluggish.

Matching pty PR: https://github.com/TerminalStudio/pty/pull/6
Matching studio PR: https://github.com/TerminalStudio/studio/pull/1