### PR TITLE
Fixes ALT + L for a Mac (German Layout)

### DIFF
--- a/lib/frontend/input_behavior_default.dart
+++ b/lib/frontend/input_behavior_default.dart
@@ -28,6 +28,7 @@ class InputBehaviorDefault extends InputBehavior {
         alt: event.isAltPressed,
         shift: event.isShiftPressed,
         mac: terminal.platform.useMacInputBehavior,
+        character: event.character,
       );
     }
   }

--- a/lib/terminal/terminal.dart
+++ b/lib/terminal/terminal.dart
@@ -412,6 +412,7 @@ class Terminal
     bool shift = false,
     bool mac = false,
     // bool meta,
+    String? character,
   }) {
     debug.onMsg(key);
 
@@ -484,8 +485,16 @@ class Terminal
     if (alt) {
       if (key.index >= TerminalKey.keyA.index &&
           key.index <= TerminalKey.keyZ.index) {
-        final input = [0x1b, key.index - TerminalKey.keyA.index + 65];
-        backend?.write(String.fromCharCodes(input));
+        final charCode = key.index - TerminalKey.keyA.index + 65;
+
+        // only process ALT + Key when this combination has no other meaning
+        // (reflected in the given character argument
+        if (character == null ||
+            character.toLowerCase() ==
+                String.fromCharCode(charCode).toLowerCase()) {
+          final input = [0x1b, key.index - TerminalKey.keyA.index + 65];
+          backend?.write(String.fromCharCodes(input));
+        }
         return;
       }
     }

--- a/lib/terminal/terminal.dart
+++ b/lib/terminal/terminal.dart
@@ -492,7 +492,7 @@ class Terminal
         if (character == null ||
             character.toLowerCase() ==
                 String.fromCharCode(charCode).toLowerCase()) {
-          final input = [0x1b, key.index - TerminalKey.keyA.index + 65];
+          final input = [0x1b, charCode];
           backend?.write(String.fromCharCodes(input));
         }
         return;

--- a/lib/terminal/terminal_isolate.dart
+++ b/lib/terminal/terminal_isolate.dart
@@ -124,8 +124,14 @@ void terminalMain(SendPort port) async {
         _terminal?.backend?.write(msg[1]);
         break;
       case _IsolateCommand.keyInput:
-        _terminal?.keyInput(msg[1],
-            ctrl: msg[2], alt: msg[3], shift: msg[4], mac: msg[5]);
+        _terminal?.keyInput(
+          msg[1],
+          ctrl: msg[2],
+          alt: msg[3],
+          shift: msg[4],
+          mac: msg[5],
+          character: msg[6],
+        );
         break;
       case _IsolateCommand.requestNewStateWhenDirty:
         if (_terminal == null) {
@@ -530,8 +536,10 @@ class TerminalIsolate with Observable implements TerminalUiInteraction {
     bool shift = false,
     bool mac = false,
     // bool meta,
+    String? character,
   }) {
-    _sendPort?.send([_IsolateCommand.keyInput, key, ctrl, alt, shift, mac]);
+    _sendPort?.send(
+        [_IsolateCommand.keyInput, key, ctrl, alt, shift, mac, character]);
   }
 
   var _isTerminated = false;

--- a/lib/terminal/terminal_ui_interaction.dart
+++ b/lib/terminal/terminal_ui_interaction.dart
@@ -117,6 +117,7 @@ abstract class TerminalUiInteraction with Observable {
     bool shift = false,
     bool mac = false,
     // bool meta,
+    String? character,
   });
 
   /// Future that fires when the backend has exited

--- a/test/frontend/input_test.mocks.dart
+++ b/test/frontend/input_test.mocks.dart
@@ -209,10 +209,18 @@ class MockTerminalUiInteraction extends _i1.Mock
           {bool? ctrl = false,
           bool? alt = false,
           bool? shift = false,
-          bool? mac = false}) =>
+          bool? mac = false,
+          String? character}) =>
       super.noSuchMethod(
-          Invocation.method(#keyInput, [key],
-              {#ctrl: ctrl, #alt: alt, #shift: shift, #mac: mac}),
+          Invocation.method(#keyInput, [
+            key
+          ], {
+            #ctrl: ctrl,
+            #alt: alt,
+            #shift: shift,
+            #mac: mac,
+            #character: character
+          }),
           returnValueForMissingStub: null);
   @override
   void terminateBackend() =>


### PR DESCRIPTION
that means '@' but also triggered "one word forward" (ALT+L)
This PR tries to detect if a key combination has a special meaning in terms of a character and only activates the ALT+`key` logic when this isn't the case.
For the German keyboard all keys are affected in that way (rendering ALT+`key` useless) so I'm not sure if this is the right approach to take.