### PR TITLE
Fixes inverse color text (when background == 0)

### DIFF
--- a/lib/frontend/terminal_painters.dart
+++ b/lib/frontend/terminal_painters.dart
@@ -266,6 +266,10 @@ class TerminalPainter extends CustomPainter {
     }
   }
 
+  int _getColor(int colorCode) {
+    return (colorCode == 0) ? 0xFF000000 : colorCode;
+  }
+
   void _paintCell(
     Canvas canvas,
     BufferLine line,
@@ -276,8 +280,8 @@ class TerminalPainter extends CustomPainter {
     int? bgColorOverride,
   }) {
     final codePoint = line.cellGetContent(cell);
-    final fgColor = fgColorOverride ?? line.cellGetFgColor(cell);
-    final bgColor = bgColorOverride ?? line.cellGetBgColor(cell);
+    final fgColor = fgColorOverride ?? _getColor(line.cellGetFgColor(cell));
+    final bgColor = bgColorOverride ?? _getColor(line.cellGetBgColor(cell));
     final flags = line.cellGetFlags(cell);
 
     if (codePoint == 0 || flags.hasFlag(CellFlags.invisible)) {


### PR DESCRIPTION
This PR adds a detection for cell color == 0 and returns black when the color is needed inverse.
This is only used for the foreground painter (background has to be transparent when not set) and solves issues when cells used inverse colors and there was no background set (which led to a transparent text rendered)