### PR TITLE
Crash fix

### DIFF
--- a/lib/frontend/terminal_view.dart
+++ b/lib/frontend/terminal_view.dart
@@ -196,7 +196,7 @@ class _TerminalViewState extends State<TerminalView> {
           // with widgets such as Scrollbar.
           return NotificationListener<ScrollNotification>(
             onNotification: (notification) {
-              onScroll(notification.metrics.pixels);
+              new Future.microtask(() => onScroll(notification.metrics.pixels));
               return false;
             },
             child: ScrollConfiguration(

--- a/lib/frontend/terminal_view.dart
+++ b/lib/frontend/terminal_view.dart
@@ -205,6 +205,9 @@ class _TerminalViewState extends State<TerminalView> {
               child: Scrollable(
                 controller: widget.scrollController,
                 viewportBuilder: (context, offset) {
+                  if (!widget.scrollController.hasClients) {
+                    return buildTerminal(context);
+                  }
                   final position = widget.scrollController.position;
 
                   /// use [_EmptyScrollActivity] to suppress unexpected behaviors


### PR DESCRIPTION
https://github.com/TerminalStudio/xterm.dart/issues/65

fix crash problem when opening vim or tmux. Use microtask to asynchronous scroll event handler.It make rebuild progress wouldn't happened in viewportBuilder so [rebuild in rebuild progress] wouldn't happen.

