### PR TITLE
fixes Issue #82

### DIFF
--- a/example/lib/isolate.dart
+++ b/example/lib/isolate.dart
@@ -43,15 +43,23 @@ class MyHomePage extends StatefulWidget {
 }
 
 class FakeTerminalBackend extends TerminalBackend {
-  final _exitCodeCompleter = Completer<int>();
+  // we do a late initialization of those backend members as the backend gets
+  // transferred into the Isolate.
+  // It is not allowed to e.g. transfer closures which we can not guarantee
+  // to not exist in our member types.
+  // The Isolate will call init() once it starts (from its context) and that is
+  // the place where we initialize those members
+  late final _exitCodeCompleter;
   // ignore: close_sinks
-  final _outStream = StreamController<String>();
+  late final _outStream;
 
   @override
   Future<int> get exitCode => _exitCodeCompleter.future;
 
   @override
   void init() {
+    _exitCodeCompleter = Completer<int>();
+    _outStream = StreamController<String>();
     _outStream.sink.add('xterm.dart demo');
     _outStream.sink.add('\r\n');
     _outStream.sink.add('\$ ');


### PR DESCRIPTION
This PR fixes the issue described in #82.
It seems that we forgot to update the Isolate example when we changed the way the backend is attached to the TerminalIsolate.
As the backend gets transferred over the Isolate boundary it is not allowed to contain any forbidden types in its object graph (like closures). To ensure that the members get initialized once the TerminalIsolate calls the init method.