### PR TITLE
Fix: resize unexpectedly duplicates currently active row

### DIFF
--- a/lib/buffer/buffer.dart
+++ b/lib/buffer/buffer.dart
@@ -505,12 +505,12 @@ class Buffer {
     }
 
     if (newHeight > oldHeight) {
-      while (lines.length < newHeight) {
-        lines.push(_newEmptyLine());
-      }
+      var initialHeight = lines.length;
       // Grow larger
       for (var i = 0; i < newHeight - oldHeight; i++) {
         if (_cursorY < oldHeight - 1) {
+          lines.push(_newEmptyLine());
+        } else if (_cursorY >= initialHeight - 1) {
           lines.push(_newEmptyLine());
         } else {
           _cursorY++;

--- a/lib/frontend/terminal_painters.dart
+++ b/lib/frontend/terminal_painters.dart
@@ -16,12 +16,14 @@ class TerminalPainter extends CustomPainter {
   TerminalPainter({
     required this.terminal,
     required this.style,
+    required this.textScaleFactor,
     required this.charSize,
     required this.textLayoutCache,
   });
 
   final TerminalUiInteraction terminal;
   final TerminalStyle style;
+  final double textScaleFactor;
   final CellSize charSize;
   final TextLayoutCache textLayoutCache;
 
@@ -306,6 +308,7 @@ class TerminalPainter extends CustomPainter {
 
     final styleToUse = PaintHelper.getStyleToUse(
       style,
+      textScaleFactor,
       color,
       bold: flags.hasFlag(CellFlags.bold),
       italic: flags.hasFlag(CellFlags.italic),
@@ -335,6 +338,7 @@ class CursorPainter extends CustomPainter {
   final String composingString;
   final TextLayoutCache textLayoutCache;
   final TerminalStyle style;
+  final double textScaleFactor;
 
   CursorPainter({
     required this.visible,
@@ -346,6 +350,7 @@ class CursorPainter extends CustomPainter {
     required this.composingString,
     required this.textLayoutCache,
     required this.style,
+    required this.textScaleFactor
   });
 
   @override
@@ -380,7 +385,7 @@ class CursorPainter extends CustomPainter {
         Rect.fromLTWH(0, 0, charSize.cellWidth, charSize.cellHeight), paint);
 
     if (composingString != '') {
-      final styleToUse = PaintHelper.getStyleToUse(style, Color(textColor));
+      final styleToUse = PaintHelper.getStyleToUse(style, textScaleFactor, Color(textColor));
       final character = textLayoutCache.performAndCacheLayout(
           composingString, styleToUse, null);
       canvas.drawParagraph(character, Offset(0, 0));
@@ -391,15 +396,17 @@ class CursorPainter extends CustomPainter {
 class PaintHelper {
   static TextStyle getStyleToUse(
     TerminalStyle style,
+    double textScaleFactor,
     Color color, {
     bool bold = false,
     bool italic = false,
     bool underline = false,
   }) {
+    var fontSize = style.fontSize * textScaleFactor;
     return (style.textStyleProvider != null)
         ? style.textStyleProvider!(
             color: color,
-            fontSize: style.fontSize,
+            fontSize: fontSize,
             fontWeight: bold && !style.ignoreBoldFlag
                 ? FontWeight.bold
                 : FontWeight.normal,
@@ -409,7 +416,7 @@ class PaintHelper {
           )
         : TextStyle(
             color: color,
-            fontSize: style.fontSize,
+            fontSize: fontSize,
             fontWeight: bold && !style.ignoreBoldFlag
                 ? FontWeight.bold
                 : FontWeight.normal,


### PR DESCRIPTION
### Issue
When changing the window height with the cursor at the bottom most portion of the viewport, the terminal would keep pushing the cursor down, even after exceeding the buffer length. For instance, using ssh, this resulted in the last line being duplicated repeatedly during resize.

### Fix
Check for cursor position exceeding buffer height and append blank rows once exceeded.  (Tests passed)