### PR TITLE
feat: make readonly accessible in TerminalView

### DIFF
--- a/lib/frontend/terminal_view.dart
+++ b/lib/frontend/terminal_view.dart
@@ -30,6 +30,7 @@ class TerminalView extends StatefulWidget {
     this.inputAction = TextInputAction.done,
     this.keyboardAppearance = Brightness.light,
     this.autocorrect = false,
+    this.readOnly = false,
     InputBehavior? inputBehavior,
     this.scrollBehavior,
     this.padding = 0.0,
@@ -47,6 +48,7 @@ class TerminalView extends StatefulWidget {
   final TextInputAction inputAction;
   final Brightness keyboardAppearance;
   final bool autocorrect;
+  final bool readOnly;
 
   final TerminalStyle style;
   final double opacity;
@@ -182,6 +184,7 @@ class _TerminalViewState extends State<TerminalView> {
       inputAction: widget.inputAction,
       keyboardAppearance: widget.keyboardAppearance,
       autocorrect: widget.autocorrect,
+      readOnly: widget.readOnly,
       child: MouseRegion(
         cursor: SystemMouseCursors.text,
         child: LayoutBuilder(builder: (context, constraints) {


### PR DESCRIPTION
The InputListener class supports a readOnly property to disable handling any input and prevents a Softkeyboard from being shown. Upto now the property was not accessible when creating a TerminalView. This PR changes that and makes it accessible.