### PR TITLE
fix: draw underline below spaces

### DIFF
--- a/lib/frontend/terminal_painters.dart
+++ b/lib/frontend/terminal_painters.dart
@@ -311,9 +311,16 @@ class TerminalPainter extends CustomPainter {
       italic: flags.hasFlag(CellFlags.italic),
       underline: flags.hasFlag(CellFlags.underline),
     );
-
-    character = textLayoutCache.performAndCacheLayout(
-        String.fromCharCode(codePoint), styleToUse, cellHash);
+    // Flutter does not draw an underline below a space which is not between
+    // other regular characters. As only single characters are drawn, this will
+    // never produce an underline below a space in the terminal. As a workaround
+    // the regular space CodePoint 0x20 is replaced with the CodePoint 0xA0.
+    // This is non breaking space and a underline can be drawn below it.
+    var c = String.fromCharCode(codePoint);
+    if (flags.hasFlag(CellFlags.underline) && codePoint == 0x20) {
+      c = String.fromCharCode(0xA0);
+    }
+    character = textLayoutCache.performAndCacheLayout(c, styleToUse, cellHash);
 
     canvas.drawParagraph(character, Offset(offsetX, offsetY));
   }

--- a/lib/next/ui/painter.dart
+++ b/lib/next/ui/painter.dart
@@ -160,9 +160,16 @@ class _TerminalLinePainter extends CustomPainter {
           italic: cellFlags & CellFlags.italic != 0,
           underline: cellFlags & CellFlags.underline != 0,
         );
-
-        paragraph = cache.performAndCacheLayout(
-            String.fromCharCode(charCode), style, hash);
+        // Flutter does not draw an underline below a space which is not between
+        // other regular characters. As only single characters are drawn, this will
+        // never produce an underline below a space in the terminal. As a workaround
+        // the regular space CodePoint 0x20 is replaced with the CodePoint 0xA0.
+        // This is non breaking space and a underline can be drawn below it.
+        var c = String.fromCharCode(charCode);
+        if (cellFlags & CellFlags.underline != 0 && charCode == 0x20) {
+          c = String.fromCharCode(0xA0);
+        }
+        paragraph = cache.performAndCacheLayout(c, style, hash);
       }
 
       canvas.drawParagraph(paragraph, Offset(i * step, 0));


### PR DESCRIPTION
Flutter only draws an underline below regular spaces on a canvas, if the the space is surrounded with other characters. Otherwise nothing will be drawn. As the painter only draws single characters at a time, underlines for spaces are never drawn. This PR fixes this behaviour by drawing spaces not as regular spaces with CharCode 0x20 but as non breaking spaces (CharCode 0xA0).  The later ones are also drawn with an underline if that is the only character to be drawn.