### PR TITLE
fix: clamp mouse position into the terminal dimension

### DIFF
--- a/lib/frontend/terminal_view.dart
+++ b/lib/frontend/terminal_view.dart
@@ -361,9 +361,14 @@ class _TerminalViewState extends State<TerminalView> {
     final col = ((px - widget.padding) / _cellSize.cellWidth).floor();
     final row = ((py - widget.padding) / _cellSize.cellHeight).floor();
 
-    final x = col;
-    final y = widget.terminal.convertViewLineToRawLine(row) -
+    var x = col;
+    var y = widget.terminal.convertViewLineToRawLine(row) -
         widget.terminal.scrollOffsetFromBottom;
+
+    // The mouse position could be outside the terminal area,
+    // in this case it is clamped back into the terminal area.
+    x = math.min(math.max(x, 0), widget.terminal.terminalWidth - 1);
+    y = math.min(math.max(y, 0), widget.terminal.terminalHeight - 1);
 
     return Position(x, y);
   }


### PR DESCRIPTION
When determining the Mouse Offset, it can happen that the resulting position is outside of the terminal. E.g. if a mouse is used to select text and  moved outside the terminal, the reported position may be outside the terminal. Currently in these case it can happen that the text selection has e.g. a negative x position.

As it doest not make sense, that the TextSelection contains a position outside the terminal, this PR ensures that this can no longer happen. Therefore additional checks are added to getMouseOffset which clamps the position into the terminal area.