### PR TITLE
feat: support block mode for text selection

### DIFF
--- a/lib/mouse/position.dart
+++ b/lib/mouse/position.dart
@@ -20,6 +20,11 @@ class Position {
     return another.y < y || (another.y == y && another.x <= x);
   }
 
+  bool isWithinRectangle(Position a, Position b) {
+    return ((a.x <= x && x <= b.x) || (b.x <= x && x <= a.x)) &&
+        ((a.y <= y && y <= b.y) || (b.y <= y && y <= a.y));
+  }
+
   @override
   String toString() {
     return 'MouseOffset($x, $y)';

--- a/lib/mouse/selection.dart
+++ b/lib/mouse/selection.dart
@@ -1,12 +1,23 @@
 import 'package:xterm/mouse/position.dart';
 
+/// SelectionMode determines how the selected area is determined.
+enum SelectionMode {
+  /// Line selects full lines between start and end position.
+  Line,
+
+  /// Block selects the rectangle spanned by start and end.
+  Block,
+}
+
 class Selection {
   Position? _start;
   Position? _end;
+  SelectionMode _mode = SelectionMode.Block;
   var _endFixed = false;
 
   Position? get start => _start;
   Position? get end => _end;
+  SelectionMode get mode => _mode;
 
   void init(Position position) {
     _start = position;
@@ -49,11 +60,27 @@ class Selection {
     if (isEmpty) {
       return false;
     }
-
-    return _start!.isBeforeOrSame(position) && _end!.isAfterOrSame(position);
+    switch (_mode) {
+      case SelectionMode.Line:
+        // Check if the position is between _start and _end.
+        return _start!.isBeforeOrSame(position) &&
+            _end!.isAfterOrSame(position);
+      case SelectionMode.Block:
+        // Check if the position is within the rectangle
+        // spanned by _start and _end.
+        return _start!.x <= position.x &&
+            position.x <= _end!.x &&
+            _start!.y <= position.y &&
+            position.y <= _end!.y;
+    }
   }
 
   bool get isEmpty {
     return _start == null || _end == null;
   }
+
+  void setMode(SelectionMode mode) {
+    _mode = mode;
+  }
+
 }

--- a/lib/mouse/selection.dart
+++ b/lib/mouse/selection.dart
@@ -31,12 +31,16 @@ class Selection {
       return;
     }
 
+    // If the start of the selection is fixed and the new position is before it,
+    // the start position becomes the end of the selection and fixed.
     if (position.isBefore(start) && !_endFixed) {
       _endFixed = true;
       _end = _start;
     }
 
-    if (position.isAfter(start) && _endFixed) {
+    // If the end of the selection is fixed and the new position is after it,
+    // the end position becomes the start of the selection and fixed.
+    if (_end != null && position.isAfter(_end!) && _endFixed) {
       _endFixed = false;
       _start = _end;
     }

--- a/lib/mouse/selection.dart
+++ b/lib/mouse/selection.dart
@@ -12,7 +12,7 @@ enum SelectionMode {
 class Selection {
   Position? _start;
   Position? _end;
-  SelectionMode _mode = SelectionMode.Block;
+  SelectionMode _mode = SelectionMode.Line;
   var _endFixed = false;
 
   Position? get start => _start;

--- a/lib/mouse/selection.dart
+++ b/lib/mouse/selection.dart
@@ -72,10 +72,7 @@ class Selection {
       case SelectionMode.Block:
         // Check if the position is within the rectangle
         // spanned by _start and _end.
-        return _start!.x <= position.x &&
-            position.x <= _end!.x &&
-            _start!.y <= position.y &&
-            position.y <= _end!.y;
+        return position.isWithinRectangle(_start!, _end!);
     }
   }
 

--- a/lib/terminal/terminal.dart
+++ b/lib/terminal/terminal.dart
@@ -361,6 +361,11 @@ class Terminal
     _mouseMode = mode;
   }
 
+  void setSelectionMode(SelectionMode mode) {
+    _selection.setMode(mode);
+    refresh();
+  }
+
   void useMainBuffer() {
     _buffer = _mainBuffer;
   }
@@ -594,8 +599,10 @@ class Terminal
           const blank = 32;
           char = blank;
         }
-
-        builder.writeCharCode(char);
+        // Check if the position is within the selection.
+        if (_selection.contains(Position(col, row))) {
+          builder.writeCharCode(char);
+        }
       }
     }
 

--- a/lib/terminal/terminal.dart
+++ b/lib/terminal/terminal.dart
@@ -578,7 +578,9 @@ class Terminal
         xStart = _selection.start!.x;
       } else if (selection!.mode == SelectionMode.Block) {
         xStart = min(_selection.start!.x, _selection.end!.x);
-      } else if (!line.isWrapped) {
+      }
+      // Add a new line character in every line after the first one.
+      if (row > _selection.start!.y && !line.isWrapped) {
         builder.write("\n");
       }
 

--- a/lib/terminal/terminal.dart
+++ b/lib/terminal/terminal.dart
@@ -574,14 +574,18 @@ class Terminal
       var xStart = 0;
       var xEnd = viewWidth - 1;
 
-      if (row == _selection.start!.y) {
+      if (row == _selection.start!.y && selection!.mode == SelectionMode.Line) {
         xStart = _selection.start!.x;
+      } else if (selection!.mode == SelectionMode.Block) {
+        xStart = min(_selection.start!.x, _selection.end!.x);
       } else if (!line.isWrapped) {
         builder.write("\n");
       }
 
-      if (row == _selection.end!.y) {
+      if (row == _selection.end!.y && selection!.mode == SelectionMode.Line) {
         xEnd = _selection.end!.x;
+      } else if (selection!.mode == SelectionMode.Block) {
+        xEnd = max(_selection.start!.x, _selection.end!.x);
       }
 
       for (var col = xStart; col <= xEnd; col++) {


### PR DESCRIPTION
This PR add support to change the text selection into a block mode. This mode does not select full lines between start and end, but the rectangular area spanned by start and end.