### PR TITLE
fix: backport resize logic

### DIFF
--- a/lib/buffer/buffer.dart
+++ b/lib/buffer/buffer.dart
@@ -505,12 +505,9 @@ class Buffer {
     }
 
     if (newHeight > oldHeight) {
-      while (lines.length < newHeight) {
-        lines.push(_newEmptyLine());
-      }
       // Grow larger
       for (var i = 0; i < newHeight - oldHeight; i++) {
-        if (_cursorY < oldHeight - 1) {
+        if (newHeight > lines.length) {
           lines.push(_newEmptyLine());
         } else {
           _cursorY++;
@@ -522,7 +519,7 @@ class Buffer {
         if (_cursorY < oldHeight - 1) {
           lines.pop();
         } else {
-          _cursorY++;
+          _cursorY--;
         }
       }
     }


### PR DESCRIPTION
This PR backports the updated (and fixed) resize logic from the next folder to the original terminal buffer.

This also fixes an issue that upon resizing to a larger size, double the number of lines are added than are required.