### PR TITLE
Allow scroll shortcuts

### DIFF
--- a/lib/frontend/terminal_view.dart
+++ b/lib/frontend/terminal_view.dart
@@ -415,7 +415,9 @@ class _TerminalViewState extends State<TerminalView> {
     blinkOscillator.restart();
     // TODO: find a way to stop scrolling immediately after key stroke.
     widget.inputBehavior.onKeyStroke(event, widget.terminal);
-    widget.terminal.setScrollOffsetFromBottom(0);
+    if (event.character?.isNotEmpty == true) {
+      widget.terminal.setScrollOffsetFromBottom(0);
+    }
   }
 
   void onFocus(bool focused) {

--- a/lib/terminal/terminal.dart
+++ b/lib/terminal/terminal.dart
@@ -473,7 +473,7 @@ class Terminal
       }
     }
 
-    if (ctrl) {
+    if (ctrl && !shift && !alt) {
       if (key.index >= TerminalKey.keyA.index &&
           key.index <= TerminalKey.keyZ.index) {
         final input = key.index - TerminalKey.keyA.index + 1;
@@ -482,7 +482,7 @@ class Terminal
       }
     }
 
-    if (alt) {
+    if (alt && !shift && !ctrl) {
       if (key.index >= TerminalKey.keyA.index &&
           key.index <= TerminalKey.keyZ.index) {
         final charCode = key.index - TerminalKey.keyA.index + 65;


### PR DESCRIPTION
Don't unconditionally force-scroll to the bottom for any (modifier) key but only if the user is actually typing in something, and fix the modifier key checks to actually allow e.g. Ctrl+Shift+Arrow shortcuts.

```dart
CallbackShortcuts(
  bindings: {
    SingleActivator(LogicalKeyboardKey.arroUp, control: true, shift: true): terminal.scrollUp,
    SingleActivator(LogicalKeyboardKey.arrowDown, control: true, shift: true): terminal.scrollDown,
    SingleActivator(LogicalKeyboardKey.pageUp, shift: true): terminal.scrollPageUp,
    SingleActivator(LogicalKeyboardKey.pageDown, shift: true): terminal.scrollPageDown,
    SingleActivator(LogicalKeyboardKey.home, shift: true): terminal.scrollToTop,
    SingleActivator(LogicalKeyboardKey.end, shift: true): terminal.scrollToBottom,
  },
  child: TerminalView(
    autofocus: true,
    terminal: terminal,
  ),
)
```

```dart
extension TerminalScroll on Terminal {
  void scrollUp() => setScrollOffsetFromBottom(scrollOffsetFromBottom + 1);
  void scrollDown() => setScrollOffsetFromBottom(scrollOffsetFromBottom - 1);
  void scrollPageUp() => setScrollOffsetFromBottom(scrollOffsetFromBottom + viewHeight);
  void scrollPageDown() => setScrollOffsetFromBottom(scrollOffsetFromBottom - viewHeight);
  void scrollToTop() => setScrollOffsetFromBottom(scrollOffsetFromBottom - viewHeight);
  void scrollToBottom() => setScrollOffsetFromBottom(0);
}
```
