### PR TITLE
feat: expose readOnly flag of CustomTextEdit in TerminalView

### DIFF
--- a/lib/src/terminal_view.dart
+++ b/lib/src/terminal_view.dart
@@ -42,6 +42,7 @@ class TerminalView extends StatefulWidget {
     this.alwaysShowCursor = false,
     this.deleteDetection = false,
     this.shortcuts,
+    this.readOnly = false,
   }) : super(key: key);
 
   /// The underlying terminal that this widget renders.
@@ -114,6 +115,9 @@ class TerminalView extends StatefulWidget {
   /// Shortcuts for this terminal. This has higher priority than input handler
   /// of the terminal If not provided, [defaultTerminalShortcuts] will be used.
   final Map<ShortcutActivator, Intent>? shortcuts;
+
+  /// True if no input should send to the terminal.
+  final bool readOnly;
 
   @override
   State<TerminalView> createState() => TerminalViewState();
@@ -219,6 +223,7 @@ class TerminalViewState extends State<TerminalView> {
         }
       },
       onKey: _onKeyEvent,
+      readOnly: widget.readOnly,
       child: child,
     );
 

--- a/test/src/terminal_view_test.dart
+++ b/test/src/terminal_view_test.dart
@@ -7,6 +7,8 @@ import 'package:xterm/xterm.dart';
 import '../_fixture/_fixture.dart';
 
 void main() {
+  final binding = TestWidgetsFlutterBinding.ensureInitialized();
+
   testWidgets(
     'Golden test',
     (WidgetTester tester) async {
@@ -27,4 +29,46 @@ void main() {
     },
     skip: !Platform.isMacOS,
   );
+
+  group('TerminalView.readOnly', () {
+    testWidgets('works', (WidgetTester tester) async {
+      final terminalOutput = <String>[];
+      final terminal = Terminal(onOutput: terminalOutput.add);
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: TerminalView(terminal, readOnly: true, autofocus: true),
+        ),
+      ));
+
+      // https://github.com/flutter/flutter/issues/11181#issuecomment-314936646
+      await tester.tap(find.byType(TerminalView));
+      await tester.pump(Duration(seconds: 1));
+
+      binding.testTextInput.enterText('ls -al');
+      await binding.idle();
+
+      expect(terminalOutput.join(), isEmpty);
+    });
+
+    testWidgets('does not block input when false', (WidgetTester tester) async {
+      final terminalOutput = <String>[];
+      final terminal = Terminal(onOutput: terminalOutput.add);
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: TerminalView(terminal, readOnly: false, autofocus: true),
+        ),
+      ));
+
+      // https://github.com/flutter/flutter/issues/11181#issuecomment-314936646
+      await tester.tap(find.byType(TerminalView));
+      await tester.pump(Duration(seconds: 1));
+
+      binding.testTextInput.enterText('ls -al');
+      await binding.idle();
+
+      expect(terminalOutput.join(), 'ls -al');
+    });
+  });
 }


### PR DESCRIPTION
This PR adds a readOnly parameter to the TerminalView, which will set the readOnly flag for the CustomTextEdit and disables any input from the TerminalView to the Terminal.

This is useful if one only wants to display the content of the terminal or if a custom soft keyboard is to be used instead of the native one.