### PR TITLE
fix: only dispose the FocusNodes which TerminalView creates

### DIFF
--- a/lib/src/terminal_view.dart
+++ b/lib/src/terminal_view.dart
@@ -153,6 +153,9 @@ class TerminalViewState extends State<TerminalView> {
   @override
   void didUpdateWidget(TerminalView oldWidget) {
     if (oldWidget.focusNode != widget.focusNode) {
+      if (oldWidget.focusNode == null) {
+        _focusNode.dispose();
+      }
       _focusNode = widget.focusNode ?? FocusNode();
     }
     if (oldWidget.controller != widget.controller) {
@@ -166,7 +169,9 @@ class TerminalViewState extends State<TerminalView> {
 
   @override
   void dispose() {
-    _focusNode.dispose();
+    if (widget.focusNode == null) {
+      _focusNode.dispose();
+    }
     _shortcutManager.dispose();
     super.dispose();
   }


### PR DESCRIPTION
This PR ensures that the TerminalView only disposes FocusNodes which it created. If the parent widget passes a FocusNode to the TerminalView, it can choose to either retain it or dispose it.