### PR TITLE
fix: export TerminalTargetPlatform

### DIFF
--- a/lib/core.dart
+++ b/lib/core.dart
@@ -14,3 +14,4 @@ export 'src/core/input/keys.dart';
 export 'src/core/mouse.dart';
 export 'src/core/state.dart';
 export 'src/terminal.dart';
+export 'src/utils/platform.dart';


### PR DESCRIPTION
This PR exports the TerminalTargetPlatform enum. The TerminalTargetPlatform enum is used for a  parameter in the Terminal constructor. Correspondingly it should be exported so that users of the package can specified it as a parameter.