### PR TITLE
feat: enable changing the inputHandler of a terminal

### DIFF
--- a/lib/src/terminal.dart
+++ b/lib/src/terminal.dart
@@ -33,8 +33,6 @@ class Terminal with Observable implements TerminalState, EscapeHandler {
   /// Flag to toggle os specific behaviors.
   final TerminalTargetPlatform platform;
 
-  final TerminalInputHandler inputHandler;
-
   Terminal({
     this.maxLines = 1000,
     this.onBell,
@@ -43,8 +41,10 @@ class Terminal with Observable implements TerminalState, EscapeHandler {
     this.onOutput,
     this.onResize,
     this.platform = TerminalTargetPlatform.unknown,
-    this.inputHandler = defaultInputHandler,
-  });
+    TerminalInputHandler inputHandler = defaultInputHandler,
+  }) : _inputHandler = inputHandler;
+
+  TerminalInputHandler _inputHandler;
 
   late final _parser = EscapeParser(this);
 
@@ -158,6 +158,10 @@ class Terminal with Observable implements TerminalState, EscapeHandler {
 
   CircularList<BufferLine> get lines => _buffer.lines;
 
+  void setInputHandler(TerminalInputHandler inputHandler) {
+    _inputHandler = inputHandler;
+  }
+
   void write(String data) {
     _parser.write(data);
     notifyListeners();
@@ -169,7 +173,7 @@ class Terminal with Observable implements TerminalState, EscapeHandler {
     bool alt = false,
     bool ctrl = false,
   }) {
-    final output = inputHandler(
+    final output = _inputHandler(
       TerminalInputEvent(
         key: key,
         shift: shift,

--- a/lib/src/terminal.dart
+++ b/lib/src/terminal.dart
@@ -30,6 +30,8 @@ class Terminal with Observable implements TerminalState, EscapeHandler {
   void Function(int width, int height, int pixelWidth, int pixelHeight)?
       onResize;
 
+  TerminalInputHandler? inputHandler;
+
   /// Flag to toggle os specific behaviors.
   final TerminalTargetPlatform platform;
 
@@ -41,10 +43,8 @@ class Terminal with Observable implements TerminalState, EscapeHandler {
     this.onOutput,
     this.onResize,
     this.platform = TerminalTargetPlatform.unknown,
-    TerminalInputHandler inputHandler = defaultInputHandler,
-  }) : _inputHandler = inputHandler;
-
-  TerminalInputHandler _inputHandler;
+    this.inputHandler = defaultInputHandler,
+  });
 
   late final _parser = EscapeParser(this);
 
@@ -158,10 +158,6 @@ class Terminal with Observable implements TerminalState, EscapeHandler {
 
   CircularList<BufferLine> get lines => _buffer.lines;
 
-  void setInputHandler(TerminalInputHandler inputHandler) {
-    _inputHandler = inputHandler;
-  }
-
   void write(String data) {
     _parser.write(data);
     notifyListeners();
@@ -173,7 +169,7 @@ class Terminal with Observable implements TerminalState, EscapeHandler {
     bool alt = false,
     bool ctrl = false,
   }) {
-    final output = _inputHandler(
+    final output = inputHandler?.call(
       TerminalInputEvent(
         key: key,
         shift: shift,

--- a/test/src/terminal_test.dart
+++ b/test/src/terminal_test.dart
@@ -1,0 +1,35 @@
+import 'package:test/test.dart';
+import 'package:xterm/core.dart';
+
+void main() {
+  group('Terminal.inputHandler', () {
+    test('can be set to null', () {
+      final terminal = Terminal(inputHandler: null);
+      expect(() => terminal.keyInput(TerminalKey.keyA), returnsNormally);
+    });
+
+    test('can be changed', () {
+      final handler1 = _TestInputHandler();
+      final handler2 = _TestInputHandler();
+      final terminal = Terminal(inputHandler: handler1);
+
+      terminal.keyInput(TerminalKey.keyA);
+      expect(handler1.events, isNotEmpty);
+
+      terminal.inputHandler = handler2;
+
+      terminal.keyInput(TerminalKey.keyA);
+      expect(handler2.events, isNotEmpty);
+    });
+  });
+}
+
+class _TestInputHandler implements TerminalInputHandler {
+  final events = <TerminalInputEvent>[];
+
+  @override
+  String? call(TerminalInputEvent event) {
+    events.add(event);
+    return null;
+  }
+}


### PR DESCRIPTION
This PR enables changing the InputHandler of a Terminal. This can be useful e.g. if one wants to temporarily intercept all traffic to terminal.