### PR TITLE
feat: block selection

### DIFF
--- a/lib/core.dart
+++ b/lib/core.dart
@@ -3,6 +3,8 @@ export 'src/core/buffer/cell_flags.dart';
 export 'src/core/buffer/cell_offset.dart';
 export 'src/core/buffer/line.dart';
 export 'src/core/buffer/range.dart';
+export 'src/core/buffer/range_block.dart';
+export 'src/core/buffer/range_line.dart';
 export 'src/core/buffer/segment.dart';
 export 'src/core/cell.dart';
 export 'src/core/color.dart';

--- a/lib/src/core/buffer/buffer.dart
+++ b/lib/src/core/buffer/buffer.dart
@@ -519,20 +519,19 @@ class Buffer {
 
     final builder = StringBuffer();
 
-    range.toSegments().forEach(
-      (segment) {
-        if (segment.line < 0 || segment.line >= height) {
-          return;
-        }
-        final line = lines[segment.line];
-        if (!(segment.line == range!.begin.y ||
-            segment.line == 0 ||
-            line.isWrapped)) {
-          builder.write("\n");
-        }
-        builder.write(line.getText(segment.start, segment.end));
-      },
-    );
+    for (var segment in range.toSegments()) {
+      if (segment.line < 0 || segment.line >= height) {
+        continue;
+      }
+      final line = lines[segment.line];
+      if (!(segment.line == range.begin.y ||
+          segment.line == 0 ||
+          line.isWrapped)) {
+        builder.write("\n");
+      }
+      builder.write(line.getText(segment.start, segment.end));
+    }
+
     return builder.toString();
   }
 

--- a/lib/src/core/buffer/buffer.dart
+++ b/lib/src/core/buffer/buffer.dart
@@ -466,7 +466,7 @@ class Buffer {
     r'\'.codeUnitAt(0),
   };
 
-  BufferRange? getWordBoundary(CellOffset position) {
+  BufferRangeLine? getWordBoundary(CellOffset position) {
     if (position.y >= lines.length) {
       return null;
     }

--- a/lib/src/core/buffer/cell_offset.dart
+++ b/lib/src/core/buffer/cell_offset.dart
@@ -36,7 +36,7 @@ class CellOffset {
   }
 
   bool isWithin(BufferRange range) {
-    return range.begin.isBeforeOrSame(this) && range.end.isAfterOrSame(this);
+    return range.contains(this);
   }
 
   @override

--- a/lib/src/core/buffer/range.dart
+++ b/lib/src/core/buffer/range.dart
@@ -1,12 +1,12 @@
 import 'package:xterm/src/core/buffer/cell_offset.dart';
 import 'package:xterm/src/core/buffer/segment.dart';
 
-class BufferRange {
+abstract class BufferRange {
   final CellOffset begin;
 
   final CellOffset end;
 
-  BufferRange(this.begin, this.end);
+  const BufferRange(this.begin, this.end);
 
   BufferRange.collapsed(this.begin) : end = begin;
 
@@ -18,45 +18,13 @@ class BufferRange {
     return begin.isEqual(end);
   }
 
-  BufferRange get normalized {
-    if (isNormalized) {
-      return this;
-    } else {
-      return BufferRange(end, begin);
-    }
-  }
+  BufferRange get normalized;
 
-  Iterable<BufferSegment> toSegments() sync* {
-    var begin = this.begin;
-    var end = this.end;
+  Iterable<BufferSegment> toSegments();
 
-    if (!isNormalized) {
-      end = this.begin;
-      begin = this.end;
-    }
-
-    for (var i = begin.y; i <= end.y; i++) {
-      var startX = i == begin.y ? begin.x : null;
-      var endX = i == end.y ? end.x : null;
-      yield BufferSegment(this, i, startX, endX);
-    }
-  }
-
-  bool contains(CellOffset position) {
-    return begin.isBeforeOrSame(position) && end.isAfterOrSame(position);
-  }
-
-  BufferRange merge(BufferRange range) {
-    final begin = this.begin.isBefore(range.begin) ? this.begin : range.begin;
-    final end = this.end.isAfter(range.end) ? this.end : range.end;
-    return BufferRange(begin, end);
-  }
-
-  BufferRange extend(CellOffset position) {
-    final begin = this.begin.isBefore(position) ? position : this.begin;
-    final end = this.end.isAfter(position) ? position : this.end;
-    return BufferRange(begin, end);
-  }
+  bool contains(CellOffset position);
+  BufferRange merge(BufferRange range);
+  BufferRange extend(CellOffset position);
 
   @override
   operator ==(Object other) {

--- a/lib/src/core/buffer/range.dart
+++ b/lib/src/core/buffer/range.dart
@@ -20,10 +20,18 @@ abstract class BufferRange {
 
   BufferRange get normalized;
 
+  /// Convert this range to segments of single lines.
   Iterable<BufferSegment> toSegments();
 
+  /// Returns true if the given[position] is within this range.
   bool contains(CellOffset position);
+
+  /// Returns the smallest range that contains both this range and the given
+  /// [range].
   BufferRange merge(BufferRange range);
+
+  /// Returns the smallest range that contains both this range and the given
+  /// [position].
   BufferRange extend(CellOffset position);
 
   @override

--- a/lib/src/core/buffer/range_block.dart
+++ b/lib/src/core/buffer/range_block.dart
@@ -1,0 +1,111 @@
+import 'dart:math';
+
+import 'package:xterm/src/core/buffer/cell_offset.dart';
+import 'package:xterm/src/core/buffer/range.dart';
+import 'package:xterm/src/core/buffer/segment.dart';
+
+class BufferRangeBlock extends BufferRange {
+  BufferRangeBlock(super.begin, super.end);
+
+  BufferRangeBlock.collapsed(CellOffset begin) : super.collapsed(begin);
+
+  @override
+  bool get isNormalized {
+    // A block range is normalized if begin is the top left corner of the range
+    // and end the bottom right corner.
+    return (begin.isBefore(end) && begin.x <= end.x) || begin.isEqual(end);
+  }
+
+  @override
+  BufferRangeBlock get normalized {
+    if (isNormalized) {
+      return this;
+    }
+    // Determine new normalized begin and end offset, such that begin is the
+    // top left corner and end is the bottom right corner of the block.
+    final normalBegin = CellOffset(min(begin.x, end.x), min(begin.y, end.y));
+    final normalEnd = CellOffset(max(begin.x, end.x), max(begin.y, end.y));
+    return BufferRangeBlock(normalBegin, normalEnd);
+  }
+
+  @override
+  Iterable<BufferSegment> toSegments() sync* {
+    var begin = this.begin;
+    var end = this.end;
+
+    if (!isNormalized) {
+      end = this.begin;
+      begin = this.end;
+    }
+
+    final startX = min(begin.x, end.x);
+    final endX = max(begin.x, end.x);
+    for (var i = begin.y; i <= end.y; i++) {
+      yield BufferSegment(this, i, startX, endX);
+    }
+  }
+
+  @override
+  bool contains(CellOffset position) {
+    var begin = this.begin;
+    var end = this.end;
+
+    if (!isNormalized) {
+      end = this.begin;
+      begin = this.end;
+    }
+    if (!(begin.y <= position.y && position.y <= end.y)) {
+      return false;
+    }
+
+    final startX = min(begin.x, end.x);
+    final endX = max(begin.x, end.x);
+    return startX <= position.x && position.x <= endX;
+  }
+
+  @override
+  BufferRangeBlock merge(BufferRange range) {
+    // Enlarge the block such that both borders of the range
+    // are within the selected block.
+    return extend(range.begin).extend(range.end);
+  }
+
+  @override
+  BufferRangeBlock extend(CellOffset position) {
+    // If the position is within the block, there is nothing to do.
+    if (contains(position)) {
+      return this;
+    }
+    // Otherwise normalize the block and push the borders outside up to
+    // the position to which the block has to extended.
+    final normal = normalized;
+    final extendBegin = CellOffset(
+      min(normal.begin.x, position.x),
+      min(normal.begin.y, position.y),
+    );
+    final extendEnd = CellOffset(
+      max(normal.end.x, position.x),
+      max(normal.end.y, position.y),
+    );
+    return BufferRangeBlock(extendBegin, extendEnd);
+  }
+
+  @override
+  operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+
+    if (other is! BufferRangeBlock) {
+      return false;
+    }
+
+    return begin == other.begin && end == other.end;
+  }
+
+  @override
+  int get hashCode => begin.hashCode ^ end.hashCode;
+
+  @override
+  String toString() => 'Block Range($begin, $end)';
+}

--- a/lib/src/core/buffer/range_line.dart
+++ b/lib/src/core/buffer/range_line.dart
@@ -1,0 +1,69 @@
+import 'package:xterm/src/core/buffer/cell_offset.dart';
+import 'package:xterm/src/core/buffer/range.dart';
+import 'package:xterm/src/core/buffer/segment.dart';
+
+class BufferRangeLine extends BufferRange {
+  BufferRangeLine(super.begin, super.end);
+
+  BufferRangeLine.collapsed(CellOffset begin) : super.collapsed(begin);
+
+  @override
+  BufferRangeLine get normalized {
+    return isNormalized ? this : BufferRangeLine(end, begin);
+  }
+
+  @override
+  Iterable<BufferSegment> toSegments() sync* {
+    var begin = this.begin;
+    var end = this.end;
+
+    if (!isNormalized) {
+      end = this.begin;
+      begin = this.end;
+    }
+
+    for (var i = begin.y; i <= end.y; i++) {
+      var startX = i == begin.y ? begin.x : null;
+      var endX = i == end.y ? end.x : null;
+      yield BufferSegment(this, i, startX, endX);
+    }
+  }
+
+  @override
+  bool contains(CellOffset position) {
+    return begin.isBeforeOrSame(position) && end.isAfterOrSame(position);
+  }
+
+  @override
+  BufferRangeLine merge(BufferRange range) {
+    final begin = this.begin.isBefore(range.begin) ? this.begin : range.begin;
+    final end = this.end.isAfter(range.end) ? this.end : range.end;
+    return BufferRangeLine(begin, end);
+  }
+
+  @override
+  BufferRangeLine extend(CellOffset position) {
+    final begin = this.begin.isBefore(position) ? position : this.begin;
+    final end = this.end.isAfter(position) ? position : this.end;
+    return BufferRangeLine(begin, end);
+  }
+
+  @override
+  operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+
+    if (other is! BufferRangeLine) {
+      return false;
+    }
+
+    return begin == other.begin && end == other.end;
+  }
+
+  @override
+  int get hashCode => begin.hashCode ^ end.hashCode;
+
+  @override
+  String toString() => 'Line Range($begin, $end)';
+}

--- a/lib/src/core/buffer/range_line.dart
+++ b/lib/src/core/buffer/range_line.dart
@@ -14,37 +14,34 @@ class BufferRangeLine extends BufferRange {
 
   @override
   Iterable<BufferSegment> toSegments() sync* {
-    var begin = this.begin;
-    var end = this.end;
-
-    if (!isNormalized) {
-      end = this.begin;
-      begin = this.end;
-    }
-
-    for (var i = begin.y; i <= end.y; i++) {
-      var startX = i == begin.y ? begin.x : null;
-      var endX = i == end.y ? end.x : null;
+    final self = normalized;
+    for (var i = self.begin.y; i <= self.end.y; i++) {
+      var startX = i == self.begin.y ? self.begin.x : null;
+      var endX = i == self.end.y ? self.end.x : null;
       yield BufferSegment(this, i, startX, endX);
     }
   }
 
   @override
   bool contains(CellOffset position) {
-    return begin.isBeforeOrSame(position) && end.isAfterOrSame(position);
+    final self = normalized;
+    return self.begin.isBeforeOrSame(position) &&
+        self.end.isAfterOrSame(position);
   }
 
   @override
   BufferRangeLine merge(BufferRange range) {
-    final begin = this.begin.isBefore(range.begin) ? this.begin : range.begin;
-    final end = this.end.isAfter(range.end) ? this.end : range.end;
+    final self = normalized;
+    final begin = self.begin.isBefore(range.begin) ? self.begin : range.begin;
+    final end = self.end.isAfter(range.end) ? self.end : range.end;
     return BufferRangeLine(begin, end);
   }
 
   @override
   BufferRangeLine extend(CellOffset position) {
-    final begin = this.begin.isBefore(position) ? position : this.begin;
-    final end = this.end.isAfter(position) ? position : this.end;
+    final self = normalized;
+    final begin = self.begin.isAfter(position) ? position : self.begin;
+    final end = self.end.isBefore(position) ? position : self.end;
     return BufferRangeLine(begin, end);
   }
 

--- a/lib/src/core/buffer/segment.dart
+++ b/lib/src/core/buffer/segment.dart
@@ -8,13 +8,15 @@ class BufferSegment {
   /// The line that this segment resides on.
   final int line;
 
-  /// The start position of this segment.
+  /// The start position of this segment. [null] means the start of the line.
   final int? start;
 
-  /// The end position of this segment. [null] if this segment is not closed.
+  /// The end position of this segment. [null] means the end of the line.
+  /// Should be greater than or equal to [start].
   final int? end;
 
-  const BufferSegment(this.range, this.line, this.start, this.end);
+  const BufferSegment(this.range, this.line, this.start, this.end)
+      : assert((start != null && end != null) ? start <= end : true);
 
   bool isWithin(CellOffset position) {
     if (position.y != line) {
@@ -33,7 +35,11 @@ class BufferSegment {
   }
 
   @override
-  String toString() => 'Segment($line, $start, $end)';
+  String toString() {
+    final start = this.start != null ? this.start.toString() : 'start';
+    final end = this.end != null ? this.end.toString() : 'end';
+    return 'Segment($line, $start -> $end)';
+  }
 
   @override
   int get hashCode =>

--- a/lib/src/ui/controller.dart
+++ b/lib/src/ui/controller.dart
@@ -1,10 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:xterm/src/core/buffer/cell_offset.dart';
 import 'package:xterm/src/core/buffer/range.dart';
+import 'package:xterm/src/core/buffer/range_block.dart';
+import 'package:xterm/src/core/buffer/range_line.dart';
+import 'package:xterm/src/ui/selection_mode.dart';
 
 class TerminalController with ChangeNotifier {
   BufferRange? _selection;
 
   BufferRange? get selection => _selection;
+
+  SelectionMode _selectionMode;
+
+  SelectionMode get selectionMode => _selectionMode;
+
+  TerminalController({SelectionMode selectionMode = SelectionMode.line})
+      : _selectionMode = selectionMode;
 
   void setSelection(BufferRange? range) {
     range = range?.normalized;
@@ -13,6 +24,38 @@ class TerminalController with ChangeNotifier {
       _selection = range;
       notifyListeners();
     }
+  }
+
+  void setSelectionRange(CellOffset begin, CellOffset end) {
+    final range = _modeRange(begin, end);
+    setSelection(range);
+  }
+
+  BufferRange _modeRange(CellOffset begin, CellOffset end) {
+    switch (selectionMode) {
+      case SelectionMode.line:
+        return BufferRangeLine(begin, end);
+      case SelectionMode.block:
+        return BufferRangeBlock(begin, end);
+    }
+  }
+
+  void setSelectionMode(SelectionMode newSelectionMode) {
+    // If the new mode is the same as the old mode,
+    // nothing has to be changed.
+    if (_selectionMode == newSelectionMode) {
+      return;
+    }
+    // Set the new mode.
+    _selectionMode = newSelectionMode;
+    // Check if an active selection exists.
+    final selection = _selection;
+    if (selection == null) {
+      notifyListeners();
+      return;
+    }
+    // Convert the selection into a selection corresponding to the new mode.
+    setSelection(_modeRange(selection.begin, selection.end));
   }
 
   void clearSelection() {

--- a/lib/src/ui/controller.dart
+++ b/lib/src/ui/controller.dart
@@ -17,6 +17,9 @@ class TerminalController with ChangeNotifier {
   TerminalController({SelectionMode selectionMode = SelectionMode.line})
       : _selectionMode = selectionMode;
 
+  /// Set selection on the terminal to [range]. For now [range] could be either
+  /// a [BufferRangeLine] or a [BufferRangeBlock]. This is not effected by
+  /// [selectionMode].
   void setSelection(BufferRange? range) {
     range = range?.normalized;
 
@@ -40,6 +43,9 @@ class TerminalController with ChangeNotifier {
     }
   }
 
+  /// Controls how the terminal behaves when the user selects a range of text.
+  /// The default is [SelectionMode.line]. Setting this to [SelectionMode.block]
+  /// enables block selection mode.
   void setSelectionMode(SelectionMode newSelectionMode) {
     // If the new mode is the same as the old mode,
     // nothing has to be changed.
@@ -58,6 +64,7 @@ class TerminalController with ChangeNotifier {
     setSelection(_modeRange(selection.begin, selection.end));
   }
 
+  /// Clears the current selection.
   void clearSelection() {
     _selection = null;
     notifyListeners();

--- a/lib/src/ui/controller.dart
+++ b/lib/src/ui/controller.dart
@@ -29,6 +29,8 @@ class TerminalController with ChangeNotifier {
     }
   }
 
+  /// Set selection on the terminal to the minimum range that contains both
+  /// [begin] and [end]. The type of range is determined by [selectionMode].
   void setSelectionRange(CellOffset begin, CellOffset end) {
     final range = _modeRange(begin, end);
     setSelection(range);

--- a/lib/src/ui/render.dart
+++ b/lib/src/ui/render.dart
@@ -276,7 +276,8 @@ class RenderTerminal extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       final toOffset = getCellOffset(to);
       final toBoundary = _terminal.buffer.getWordBoundary(toOffset);
       if (toBoundary == null) return;
-      _controller.setSelection(fromBoundary.merge(toBoundary));
+      final range = fromBoundary.merge(toBoundary);
+      _controller.setSelectionRange(range.begin, range.end);
     }
   }
 
@@ -284,10 +285,10 @@ class RenderTerminal extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   void selectCharacters(Offset from, [Offset? to]) {
     final fromPosition = getCellOffset(from);
     if (to == null) {
-      _controller.setSelection(BufferRange.collapsed(fromPosition));
+      _controller.setSelectionRange(fromPosition, fromPosition);
     } else {
       final toPosition = getCellOffset(to);
-      _controller.setSelection(BufferRange(fromPosition, toPosition));
+      _controller.setSelectionRange(fromPosition, toPosition);
     }
   }
 

--- a/lib/src/ui/render.dart
+++ b/lib/src/ui/render.dart
@@ -276,18 +276,21 @@ class RenderTerminal extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       final toOffset = getCellOffset(to);
       final toBoundary = _terminal.buffer.getWordBoundary(toOffset);
       if (toBoundary == null) return;
-      final range = fromBoundary.merge(toBoundary);
-      _controller.setSelectionRange(range.begin, range.end);
+      _controller.setSelection(fromBoundary.merge(toBoundary));
     }
   }
 
-  /// Selects characters in the terminal that starts from [from] to [to].
+  /// Selects characters in the terminal that starts from [from] to [to]. At
+  /// least one cell is selected even if [from] and [to] are same.
   void selectCharacters(Offset from, [Offset? to]) {
     final fromPosition = getCellOffset(from);
     if (to == null) {
       _controller.setSelectionRange(fromPosition, fromPosition);
     } else {
-      final toPosition = getCellOffset(to);
+      var toPosition = getCellOffset(to);
+      if (toPosition.x >= fromPosition.x) {
+        toPosition = CellOffset(toPosition.x + 1, toPosition.y);
+      }
       _controller.setSelectionRange(fromPosition, toPosition);
     }
   }

--- a/lib/src/ui/selection_mode.dart
+++ b/lib/src/ui/selection_mode.dart
@@ -1,0 +1,5 @@
+enum SelectionMode {
+  line,
+
+  block,
+}

--- a/lib/src/ui/shortcut/actions.dart
+++ b/lib/src/ui/shortcut/actions.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:xterm/src/core/buffer/cell_offset.dart';
-import 'package:xterm/src/core/buffer/range.dart';
+import 'package:xterm/src/core/buffer/range_line.dart';
 import 'package:xterm/src/terminal.dart';
 import 'package:xterm/src/ui/controller.dart';
 
@@ -54,7 +54,7 @@ class TerminalActions extends StatelessWidget {
         SelectAllTextIntent: CallbackAction<SelectAllTextIntent>(
           onInvoke: (intent) {
             controller.setSelection(
-              BufferRange(
+              BufferRangeLine(
                 CellOffset(0, terminal.buffer.height - terminal.viewHeight),
                 CellOffset(terminal.viewWidth, terminal.buffer.height - 1),
               ),

--- a/lib/ui.dart
+++ b/lib/ui.dart
@@ -2,6 +2,7 @@ export 'src/terminal_view.dart';
 export 'src/ui/controller.dart';
 export 'src/ui/cursor_type.dart';
 export 'src/ui/keyboard_visibility.dart';
+export 'src/ui/selection_mode.dart';
 export 'src/ui/shortcut/shortcuts.dart';
 export 'src/ui/terminal_text_style.dart';
 export 'src/ui/terminal_theme.dart';

--- a/test/src/core/buffer/buffer_test.dart
+++ b/test/src/core/buffer/buffer_test.dart
@@ -37,7 +37,7 @@ void main() {
 
       expect(
         terminal.buffer.getText(
-          BufferRange(CellOffset(-100, -100), CellOffset(100, 100)),
+          BufferRangeLine(CellOffset(-100, -100), CellOffset(100, 100)),
         ),
         startsWith('Hello World'),
       );
@@ -50,7 +50,7 @@ void main() {
 
       expect(
         terminal.buffer.getText(
-          BufferRange(CellOffset(0, 0), CellOffset(100, 100)),
+          BufferRangeLine(CellOffset(0, 0), CellOffset(100, 100)),
         ),
         startsWith('Hello World'),
       );
@@ -63,9 +63,23 @@ void main() {
 
       expect(
         terminal.buffer.getText(
-          BufferRange(CellOffset(5, 5), CellOffset(0, 0)),
+          BufferRangeLine(CellOffset(5, 5), CellOffset(0, 0)),
         ),
         startsWith('Hello World'),
+      );
+    });
+
+    test('can handle block range', () {
+      final terminal = Terminal();
+
+      terminal.write('Hello World\r\n');
+      terminal.write('Nice to meet you\r\n');
+
+      expect(
+        terminal.buffer.getText(
+          BufferRangeBlock(CellOffset(2, 0), CellOffset(5, 1)),
+        ),
+        startsWith('llo\nce '),
       );
     });
   });

--- a/test/src/core/buffer/range_block_test.dart
+++ b/test/src/core/buffer/range_block_test.dart
@@ -1,0 +1,107 @@
+import 'package:test/test.dart';
+import 'package:xterm/xterm.dart';
+
+void main() {
+  group('BufferLineRange', () {
+    test('toSegments() works', () {
+      final range = BufferRangeBlock(CellOffset(10, 10), CellOffset(12, 12));
+      final segments = range.toSegments().toList();
+
+      expect(segments, hasLength(3));
+
+      expect(segments[0].start, equals(10));
+      expect(segments[0].end, equals(12));
+
+      expect(segments[1].start, equals(10));
+      expect(segments[1].end, equals(12));
+
+      expect(segments[2].start, equals(10));
+      expect(segments[2].end, 12);
+    });
+
+    test('toSegments() works with reversed range', () {
+      final range = BufferRangeBlock(CellOffset(12, 12), CellOffset(10, 10));
+      final segments = range.toSegments().toList();
+
+      expect(segments, hasLength(3));
+
+      expect(segments[0].start, equals(10));
+      expect(segments[0].end, equals(12));
+
+      expect(segments[1].start, equals(10));
+      expect(segments[1].end, equals(12));
+
+      expect(segments[2].start, equals(10));
+      expect(segments[2].end, 12);
+    });
+
+    test('contains() works', () {
+      final range = BufferRangeBlock(CellOffset(10, 10), CellOffset(10, 12));
+
+      expect(range.contains(CellOffset(10, 10)), isTrue);
+      expect(range.contains(CellOffset(10, 11)), isTrue);
+      expect(range.contains(CellOffset(10, 12)), isTrue);
+
+      expect(range.contains(CellOffset(10, 9)), isFalse);
+      expect(range.contains(CellOffset(10, 13)), isFalse);
+    });
+
+    test('contains() works with reversed range', () {
+      final range = BufferRangeBlock(CellOffset(10, 12), CellOffset(10, 10));
+
+      expect(range.contains(CellOffset(10, 10)), isTrue);
+      expect(range.contains(CellOffset(10, 11)), isTrue);
+      expect(range.contains(CellOffset(10, 12)), isTrue);
+
+      expect(range.contains(CellOffset(10, 9)), isFalse);
+      expect(range.contains(CellOffset(10, 13)), isFalse);
+    });
+
+    test('merge() works', () {
+      final range1 = BufferRangeBlock(CellOffset(10, 10), CellOffset(10, 12));
+      final range2 = BufferRangeBlock(CellOffset(10, 13), CellOffset(10, 15));
+
+      final merged = range1.merge(range2);
+
+      expect(merged.begin, equals(CellOffset(10, 10)));
+      expect(merged.end, equals(CellOffset(10, 15)));
+    });
+
+    test('merge() works with reversed range', () {
+      final range1 = BufferRangeBlock(CellOffset(10, 12), CellOffset(10, 10));
+      final range2 = BufferRangeBlock(CellOffset(10, 13), CellOffset(10, 15));
+
+      final merged = range1.merge(range2);
+
+      expect(merged.begin, equals(CellOffset(10, 10)));
+      expect(merged.end, equals(CellOffset(10, 15)));
+    });
+
+    test('extend() works', () {
+      final range = BufferRangeBlock(CellOffset(10, 10), CellOffset(10, 12));
+
+      final extended = range.extend(CellOffset(10, 13));
+
+      expect(extended.begin, equals(CellOffset(10, 10)));
+      expect(extended.end, equals(CellOffset(10, 13)));
+    });
+
+    test('extend() works with reversed range', () {
+      final range = BufferRangeBlock(CellOffset(10, 12), CellOffset(10, 10));
+
+      final extended = range.extend(CellOffset(10, 13));
+
+      expect(extended.begin, equals(CellOffset(10, 10)));
+      expect(extended.end, equals(CellOffset(10, 13)));
+    });
+
+    test('extend() works with reversed range and reversed extend', () {
+      final range = BufferRangeBlock(CellOffset(10, 12), CellOffset(10, 10));
+
+      final extended = range.extend(CellOffset(10, 9));
+
+      expect(extended.begin, equals(CellOffset(10, 9)));
+      expect(extended.end, equals(CellOffset(10, 12)));
+    });
+  });
+}

--- a/test/src/core/buffer/range_line_test.dart
+++ b/test/src/core/buffer/range_line_test.dart
@@ -1,0 +1,107 @@
+import 'package:test/test.dart';
+import 'package:xterm/xterm.dart';
+
+void main() {
+  group('BufferRangeLine', () {
+    test('toSegments() works', () {
+      final range = BufferRangeLine(CellOffset(10, 10), CellOffset(10, 12));
+      final segments = range.toSegments().toList();
+
+      expect(segments, hasLength(3));
+
+      expect(segments[0].start, equals(10));
+      expect(segments[0].end, null);
+
+      expect(segments[1].start, null);
+      expect(segments[1].end, null);
+
+      expect(segments[2].start, null);
+      expect(segments[2].end, 10);
+    });
+
+    test('toSegments() works with reversed range', () {
+      final range = BufferRangeLine(CellOffset(10, 12), CellOffset(10, 10));
+      final segments = range.toSegments().toList();
+
+      expect(segments, hasLength(3));
+
+      expect(segments[0].start, 10);
+      expect(segments[0].end, null);
+
+      expect(segments[1].start, null);
+      expect(segments[1].end, null);
+
+      expect(segments[2].start, null);
+      expect(segments[2].end, 10);
+    });
+
+    test('contains() works', () {
+      final range = BufferRangeLine(CellOffset(10, 10), CellOffset(10, 12));
+
+      expect(range.contains(CellOffset(10, 10)), isTrue);
+      expect(range.contains(CellOffset(10, 11)), isTrue);
+      expect(range.contains(CellOffset(10, 12)), isTrue);
+
+      expect(range.contains(CellOffset(10, 9)), isFalse);
+      expect(range.contains(CellOffset(10, 13)), isFalse);
+    });
+
+    test('contains() works with reversed range', () {
+      final range = BufferRangeLine(CellOffset(10, 12), CellOffset(10, 10));
+
+      expect(range.contains(CellOffset(10, 10)), isTrue);
+      expect(range.contains(CellOffset(10, 11)), isTrue);
+      expect(range.contains(CellOffset(10, 12)), isTrue);
+
+      expect(range.contains(CellOffset(10, 9)), isFalse);
+      expect(range.contains(CellOffset(10, 13)), isFalse);
+    });
+
+    test('merge() works', () {
+      final range1 = BufferRangeLine(CellOffset(10, 10), CellOffset(10, 12));
+      final range2 = BufferRangeLine(CellOffset(10, 13), CellOffset(10, 15));
+
+      final merged = range1.merge(range2);
+
+      expect(merged.begin, equals(CellOffset(10, 10)));
+      expect(merged.end, equals(CellOffset(10, 15)));
+    });
+
+    test('merge() works with reversed range', () {
+      final range1 = BufferRangeLine(CellOffset(10, 12), CellOffset(10, 10));
+      final range2 = BufferRangeLine(CellOffset(10, 13), CellOffset(10, 15));
+
+      final merged = range1.merge(range2);
+
+      expect(merged.begin, equals(CellOffset(10, 10)));
+      expect(merged.end, equals(CellOffset(10, 15)));
+    });
+
+    test('extend() works', () {
+      final range = BufferRangeLine(CellOffset(10, 10), CellOffset(10, 12));
+
+      final extended = range.extend(CellOffset(10, 13));
+
+      expect(extended.begin, equals(CellOffset(10, 10)));
+      expect(extended.end, equals(CellOffset(10, 13)));
+    });
+
+    test('extend() works with reversed range', () {
+      final range = BufferRangeLine(CellOffset(10, 12), CellOffset(10, 10));
+
+      final extended = range.extend(CellOffset(10, 13));
+
+      expect(extended.begin, equals(CellOffset(10, 10)));
+      expect(extended.end, equals(CellOffset(10, 13)));
+    });
+
+    test('extend() works with reversed range and reversed extend', () {
+      final range = BufferRangeLine(CellOffset(10, 12), CellOffset(10, 10));
+
+      final extended = range.extend(CellOffset(10, 9));
+
+      expect(extended.begin, equals(CellOffset(10, 9)));
+      expect(extended.end, equals(CellOffset(10, 12)));
+    });
+  });
+}

--- a/test/src/core/buffer/segment_test.dart
+++ b/test/src/core/buffer/segment_test.dart
@@ -1,0 +1,32 @@
+import 'package:test/test.dart';
+import 'package:xterm/xterm.dart';
+
+void main() {
+  group('BufferSegment', () {
+    test('isWithin() works', () {
+      final segments = BufferRangeLine(CellOffset(10, 10), CellOffset(10, 12))
+          .toSegments()
+          .toList();
+
+      expect(segments[0].start, equals(10));
+      expect(segments[0].end, null);
+      expect(segments[0].isWithin(CellOffset(10, 10)), isTrue);
+      expect(segments[0].isWithin(CellOffset(11, 10)), isTrue);
+      expect(segments[0].isWithin(CellOffset(100, 10)), isTrue);
+      expect(segments[0].isWithin(CellOffset(9, 10)), isFalse);
+
+      expect(segments[1].start, null);
+      expect(segments[1].end, null);
+      expect(segments[1].isWithin(CellOffset(10, 11)), isTrue);
+      expect(segments[1].isWithin(CellOffset(11, 11)), isTrue);
+      expect(segments[1].isWithin(CellOffset(100, 11)), isTrue);
+      expect(segments[1].isWithin(CellOffset(0, 11)), isTrue);
+
+      expect(segments[2].start, null);
+      expect(segments[2].end, 10);
+      expect(segments[2].isWithin(CellOffset(0, 12)), isTrue);
+      expect(segments[2].isWithin(CellOffset(10, 12)), isTrue);
+      expect(segments[2].isWithin(CellOffset(11, 12)), isFalse);
+    });
+  });
+}

--- a/test/src/ui/controller_test.dart
+++ b/test/src/ui/controller_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xterm/xterm.dart';
+
+void main() {
+  group('TerminalController', () {
+    testWidgets('setSelectionRange works', (tester) async {
+      final terminal = Terminal();
+      final terminalView = TerminalController();
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: TerminalView(
+            terminal,
+            controller: terminalView,
+          ),
+        ),
+      ));
+
+      terminalView.setSelectionRange(CellOffset(0, 0), CellOffset(2, 2));
+
+      await tester.pump();
+
+      expect(terminalView.selection, isNotNull);
+    });
+
+    testWidgets('setSelectionMode changes BufferRange type', (tester) async {
+      final terminal = Terminal();
+      final terminalView = TerminalController();
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: TerminalView(
+            terminal,
+            controller: terminalView,
+          ),
+        ),
+      ));
+
+      terminalView.setSelectionRange(CellOffset(0, 0), CellOffset(2, 2));
+
+      expect(terminalView.selection, isA<BufferRangeLine>());
+
+      terminalView.setSelectionMode(SelectionMode.block);
+
+      expect(terminalView.selection, isA<BufferRangeBlock>());
+    });
+
+    testWidgets('clearSelection works', (tester) async {
+      final terminal = Terminal();
+      final terminalView = TerminalController();
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: TerminalView(
+            terminal,
+            controller: terminalView,
+          ),
+        ),
+      ));
+
+      terminalView.setSelectionRange(CellOffset(0, 0), CellOffset(2, 2));
+
+      expect(terminalView.selection, isNotNull);
+
+      terminalView.clearSelection();
+
+      expect(terminalView.selection, isNull);
+    });
+  });
+}


### PR DESCRIPTION
This PR enables selecting a block within the terminal buffer. For this purpose an additional class BufferRangeBlock is created. The current BufferRange is renamed to BufferRangeLine and a common interface BufferRange is created for both classes. Switching between block and line selection is done using the TerminalController.

Selecting a block of text is useful e.g. if data is shown in a tabular format in the terminal and one is only interested in copying the data in some columns.

