### PR TITLE
fix: workaround to draw underlined spaces

### DIFF
--- a/lib/src/ui/render.dart
+++ b/lib/src/ui/render.dart
@@ -580,19 +580,20 @@ class RenderTerminal extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
         italic: cellFlags & CellFlags.italic != 0,
         underline: cellFlags & CellFlags.underline != 0,
       );
+
       // Flutter does not draw an underline below a space which is not between
       // other regular characters. As only single characters are drawn, this
       // will never produce an underline below a space in the terminal. As a
       // workaround the regular space CodePoint 0x20 is replaced with
       // the CodePoint 0xA0. This is a non breaking space and a underline can be
       // drawn below it.
-      var c = String.fromCharCode(charCode);
+      var char = String.fromCharCode(charCode);
       if (cellFlags & CellFlags.underline != 0 && charCode == 0x20) {
-        c = String.fromCharCode(0xA0);
+        char = String.fromCharCode(0xA0);
       }
 
       paragraph = _paragraphCache.performAndCacheLayout(
-        c,
+        char,
         style,
         hash,
       );

--- a/lib/src/ui/render.dart
+++ b/lib/src/ui/render.dart
@@ -580,9 +580,19 @@ class RenderTerminal extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
         italic: cellFlags & CellFlags.italic != 0,
         underline: cellFlags & CellFlags.underline != 0,
       );
+      // Flutter does not draw an underline below a space which is not between
+      // other regular characters. As only single characters are drawn, this
+      // will never produce an underline below a space in the terminal. As a
+      // workaround the regular space CodePoint 0x20 is replaced with
+      // the CodePoint 0xA0. This is a non breaking space and a underline can be
+      // drawn below it.
+      var c = String.fromCharCode(charCode);
+      if (cellFlags & CellFlags.underline != 0 && charCode == 0x20) {
+        c = String.fromCharCode(0xA0);
+      }
 
       paragraph = _paragraphCache.performAndCacheLayout(
-        String.fromCharCode(charCode),
+        c,
         style,
         hash,
       );


### PR DESCRIPTION
Flutter only draws an underline below regular spaces on a canvas, if the space is surrounded with other characters. Otherwise nothing will be drawn. As the painter only draws single characters at a time, underlines for spaces are never drawn. This PR fixes this behaviour by drawing spaces not as regular spaces with CharCode 0x20 but as non breaking spaces (CharCode 0xA0). The later ones are also drawn with an underline if that is the only character to be drawn.