### PR TITLE
fix: dispose controllers of TerminalView 

### DIFF
--- a/lib/src/terminal_view.dart
+++ b/lib/src/terminal_view.dart
@@ -124,7 +124,7 @@ class TerminalView extends StatefulWidget {
 }
 
 class TerminalViewState extends State<TerminalView> {
-  late final FocusNode _focusNode;
+  late FocusNode _focusNode;
 
   late final ShortcutManager _shortcutManager;
 

--- a/lib/src/terminal_view.dart
+++ b/lib/src/terminal_view.dart
@@ -163,9 +163,15 @@ class TerminalViewState extends State<TerminalView> {
       _focusNode = widget.focusNode ?? FocusNode();
     }
     if (oldWidget.controller != widget.controller) {
+      if (oldWidget.controller == null) {
+        _controller.dispose();
+      }
       _controller = widget.controller ?? TerminalController();
     }
     if (oldWidget.scrollController != widget.scrollController) {
+      if (oldWidget.scrollController == null) {
+        _scrollController.dispose();
+      }
       _scrollController = widget.scrollController ?? ScrollController();
     }
     super.didUpdateWidget(oldWidget);
@@ -175,6 +181,12 @@ class TerminalViewState extends State<TerminalView> {
   void dispose() {
     if (widget.focusNode == null) {
       _focusNode.dispose();
+    }
+    if (widget.controller == null) {
+      _controller.dispose();
+    }
+    if (widget.scrollController == null) {
+      _scrollController.dispose();
     }
     _shortcutManager.dispose();
     super.dispose();


### PR DESCRIPTION
This PR fixes two issues with the TerminalView state. 

First the _focusNode property may not be final as it can be overridden, if the widget updates and specifies another FocusNode object.

Second the TerminalController and the ScrollController have to be disposed if they were crated during state initialisation or during a widget update.