### PR TITLE
feat: shortcuts may provide a custom action for the intent

### DIFF
--- a/lib/src/ui/shortcut/actions.dart
+++ b/lib/src/ui/shortcut/actions.dart
@@ -1,15 +1,14 @@
-import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:xterm/src/core/buffer/cell_offset.dart';
-import 'package:xterm/src/core/buffer/range_line.dart';
 import 'package:xterm/src/terminal.dart';
 import 'package:xterm/src/ui/controller.dart';
+import 'package:xterm/src/ui/shortcut/shortcuts.dart';
 
 class TerminalActions extends StatelessWidget {
   const TerminalActions({
     super.key,
     required this.terminal,
     required this.controller,
+    required this.shortcuts,
     required this.child,
   });
 
@@ -17,51 +16,16 @@ class TerminalActions extends StatelessWidget {
 
   final TerminalController controller;
 
+  final List<TerminalShortcut> shortcuts;
+
   final Widget child;
 
   @override
   Widget build(BuildContext context) {
-    return Actions(
-      actions: {
-        PasteTextIntent: CallbackAction<PasteTextIntent>(
-          onInvoke: (intent) async {
-            final data = await Clipboard.getData(Clipboard.kTextPlain);
-            final text = data?.text;
-            if (text != null) {
-              terminal.paste(text);
-              controller.clearSelection();
-            }
-            return null;
-          },
-        ),
-        CopySelectionTextIntent: CallbackAction<CopySelectionTextIntent>(
-          onInvoke: (intent) async {
-            final selection = controller.selection;
-
-            if (selection == null) {
-              return;
-            }
-
-            final text = terminal.buffer.getText(selection);
-
-            await Clipboard.setData(ClipboardData(text: text));
-
-            return null;
-          },
-        ),
-        SelectAllTextIntent: CallbackAction<SelectAllTextIntent>(
-          onInvoke: (intent) {
-            controller.setSelection(
-              BufferRangeLine(
-                CellOffset(0, terminal.buffer.height - terminal.viewHeight),
-                CellOffset(terminal.viewWidth, terminal.buffer.height - 1),
-              ),
-            );
-            return null;
-          },
-        ),
-      },
-      child: child,
+    // Convert the list of shortcuts to a callback map.
+    final actions = Map.fromEntries(
+      shortcuts.map((e) => e.toActionMapEntry(terminal, controller)),
     );
+    return Actions(actions: actions, child: child);
   }
 }

--- a/lib/src/ui/shortcut/shortcuts.dart
+++ b/lib/src/ui/shortcut/shortcuts.dart
@@ -1,34 +1,134 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart';
 
-Map<ShortcutActivator, Intent> get defaultTerminalShortcuts {
-  switch (defaultTargetPlatform) {
-    case TargetPlatform.android:
-    case TargetPlatform.fuchsia:
-    case TargetPlatform.linux:
-    case TargetPlatform.windows:
-      return _defaultShortcuts;
-    case TargetPlatform.iOS:
-    case TargetPlatform.macOS:
-      return _defaultAppleShortcuts;
+import 'package:xterm/src/core/buffer/cell_offset.dart';
+import 'package:xterm/src/core/buffer/range_line.dart';
+import 'package:xterm/src/terminal.dart';
+import 'package:xterm/src/ui/controller.dart';
+
+class TerminalShortcut<T extends Intent> {
+  /// The activator which triggers the the intent.
+  final ShortcutActivator activator;
+
+  /// The intent that is triggered bt the activator.
+  final T intent;
+
+  /// The action to run when the shortcut is invoked.
+  final Object? Function(T, Terminal, TerminalController) action;
+
+  const TerminalShortcut(this.activator, this.intent, this.action);
+
+  /// Use the default modifier key for the current platform so assemble a
+  /// key combination for the shortcut. On iOS the macOS the shortcut will be
+  /// triggered my META + [key], otherwise CTRL + [key] triggers the shortcut.
+  factory TerminalShortcut.platformDefault(
+    LogicalKeyboardKey key,
+    T intent,
+    Object? Function(T, Terminal, TerminalController) action,
+  ) {
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.linux:
+      case TargetPlatform.windows:
+        return TerminalShortcut(
+          SingleActivator(key, control: true),
+          intent,
+          action,
+        );
+      case TargetPlatform.iOS:
+      case TargetPlatform.macOS:
+        return TerminalShortcut(
+          SingleActivator(key, meta: true),
+          intent,
+          action,
+        );
+    }
+  }
+
+  /// Convert the shortcut to a [MapEntry] for passing it to an [Action] Widget.
+  MapEntry<Type, Action<T>> toActionMapEntry(
+    Terminal terminal,
+    TerminalController terminalController,
+  ) {
+    return MapEntry(
+      intent.runtimeType,
+      CallbackAction<T>(
+        onInvoke: (intent) => action(intent, terminal, terminalController),
+      ),
+    );
+  }
+
+  /// Generate a list of default shortcuts for the current platform.
+  static List<TerminalShortcut> get defaults {
+    return <TerminalShortcut>[
+      TerminalShortcut<CopySelectionTextIntent>.platformDefault(
+        LogicalKeyboardKey.keyC,
+        CopySelectionTextIntent.copy,
+        TerminalShortcut.defaultCopy,
+      ),
+      TerminalShortcut<PasteTextIntent>.platformDefault(
+        LogicalKeyboardKey.keyV,
+        const PasteTextIntent(SelectionChangedCause.keyboard),
+        TerminalShortcut.defaultPaste,
+      ),
+      TerminalShortcut<SelectAllTextIntent>.platformDefault(
+        LogicalKeyboardKey.keyA,
+        const SelectAllTextIntent(SelectionChangedCause.keyboard),
+        TerminalShortcut.defaultSelectAll,
+      ),
+    ];
+  }
+
+  /// Default handler for [CopySelectionTextIntent].
+  static Object? defaultCopy(
+    CopySelectionTextIntent intent,
+    Terminal terminal,
+    TerminalController controller,
+  ) async {
+    final selection = controller.selection;
+
+    if (selection == null) {
+      return null;
+    }
+
+    final text = terminal.buffer.getText(selection);
+
+    await Clipboard.setData(ClipboardData(text: text));
+
+    return null;
+  }
+
+  /// Default handler for [PasteTextIntent].
+  static Object? defaultPaste(
+    PasteTextIntent intent,
+    Terminal terminal,
+    TerminalController controller,
+  ) async {
+    final data = await Clipboard.getData(Clipboard.kTextPlain);
+    final text = data?.text;
+    if (text != null) {
+      terminal.paste(text);
+      controller.clearSelection();
+    }
+
+    return null;
+  }
+
+
+  /// Default handler for [SelectAllTextIntent].
+  static Object? defaultSelectAll(
+    SelectAllTextIntent intent,
+    Terminal terminal,
+    TerminalController controller,
+  ) async {
+    controller.setSelection(
+      BufferRangeLine(
+        CellOffset(0, terminal.buffer.height - terminal.viewHeight),
+        CellOffset(terminal.viewWidth, terminal.buffer.height - 1),
+      ),
+    );
+    return null;
   }
 }
-
-final _defaultShortcuts = {
-  SingleActivator(LogicalKeyboardKey.keyC, control: true):
-      CopySelectionTextIntent.copy,
-  SingleActivator(LogicalKeyboardKey.keyV, control: true):
-      const PasteTextIntent(SelectionChangedCause.keyboard),
-  SingleActivator(LogicalKeyboardKey.keyA, control: true):
-      const SelectAllTextIntent(SelectionChangedCause.keyboard),
-};
-
-final _defaultAppleShortcuts = {
-  SingleActivator(LogicalKeyboardKey.keyC, meta: true):
-      CopySelectionTextIntent.copy,
-  SingleActivator(LogicalKeyboardKey.keyV, meta: true):
-      const PasteTextIntent(SelectionChangedCause.keyboard),
-  SingleActivator(LogicalKeyboardKey.keyA, meta: true):
-      const SelectAllTextIntent(SelectionChangedCause.keyboard),
-};


### PR DESCRIPTION
This PR adds the possibility to set a custom action callback function for the intent corresponding to the shortcut. This can be useful for example, if the text to be pasted should be preprocessed before writing it to the terminal. For example special characters could cause problems could be removed.

The PR also adds handling of changes to the shortcuts property of the TerminalView. A new ShortcutManager is created in case the list of shortcuts. changes.

Furthermore it has been made easier to override default shortcuts, by adding a constructor to chose the proper modifier key for the current platform.