### PR TITLE
Sync ShortcutManager's shortcuts in didUpdateWidget

### DIFF
--- a/lib/src/terminal_view.dart
+++ b/lib/src/terminal_view.dart
@@ -180,6 +180,7 @@ class TerminalViewState extends State<TerminalView> {
       }
       _scrollController = widget.scrollController ?? ScrollController();
     }
+    _shortcutManager.shortcuts = widget.shortcuts ?? defaultTerminalShortcuts;
     super.didUpdateWidget(oldWidget);
   }
 


### PR DESCRIPTION
If `TerminalView` is rebuilt with a different set of shortcuts, make sure to pass them to `ShortcutManager`.