### PR TITLE
Fix Flutter 3.7 incompatibilities

### DIFF
--- a/example/lib/src/platform_menu.dart
+++ b/example/lib/src/platform_menu.dart
@@ -20,7 +20,7 @@ class _AppPlatformMenuState extends State<AppPlatformMenu> {
     }
 
     return PlatformMenuBar(
-      menus: <MenuItem>[
+      menus: [
         PlatformMenu(
           label: 'TerminalStudio',
           menus: [

--- a/lib/src/ui/custom_text_edit.dart
+++ b/lib/src/ui/custom_text_edit.dart
@@ -51,8 +51,7 @@ class CustomTextEdit extends StatefulWidget {
   CustomTextEditState createState() => CustomTextEditState();
 }
 
-class CustomTextEditState extends State<CustomTextEdit>
-    implements TextInputClient {
+class CustomTextEditState extends State<CustomTextEdit> with TextInputClient {
   TextInputConnection? _connection;
 
   @override


### PR DESCRIPTION
- Mix `TextInputClient` into `CustomTextEditState` instead of implementing all of it to avoid breaking whenever a new `TextInputClient` member is introduced.
- `MenuItem` was renamed to `PlatformMenuItem`. Drop the explicit type in the example to support both versions.

Fixes: #150