### PR TITLE
Added support for Ctrl+Home, Ctrl+End etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [upcoming]
 * Support customizing word separators for selection [#160]. Thanks [@itzhoujun].
 * Fix incorrect tab stop handling [#161]. Thanks [@itzhoujun].
+* Added support for Ctrl+Home, Ctrl+End etc [#169]. Thanks [@nuc134r].
 
 ## [3.4.1] - 2023-01-27
 * Fix Flutter 3.7 incompatibilities [#151], thanks [@jpnurmi].
@@ -209,6 +210,7 @@
 [@LucasAschenbach]: https://github.com/LucasAschenbach
 [@tauu]: https://github.com/tauu
 [@itzhoujun]: https://github.com/itzhoujun
+[@nuc134r]: https://github.com/nuc134r
 
 
 [#40]: https://github.com/TerminalStudio/xterm.dart/pull/40
@@ -255,4 +257,5 @@
 
 [#160]: https://github.com/TerminalStudio/xterm.dart/pull/160
 [#161]: https://github.com/TerminalStudio/xterm.dart/pull/161
+[#169]: https://github.com/TerminalStudio/xterm.dart/pull/169
 

--- a/lib/src/core/input/handler.dart
+++ b/lib/src/core/input/handler.dart
@@ -1,7 +1,7 @@
 import 'package:xterm/src/core/input/keys.dart';
 import 'package:xterm/src/core/input/keytab/keytab.dart';
-import 'package:xterm/src/utils/platform.dart';
 import 'package:xterm/src/core/state.dart';
+import 'package:xterm/src/utils/platform.dart';
 
 /// The key event received from the keyboard, along with the state of the
 /// modifier keys and state of the terminal. Typically consumed by the
@@ -124,7 +124,35 @@ class KeytabInputHandler implements TerminalInputHandler {
       return null;
     }
 
-    return action.action.unescapedValue();
+    var result = action.action.unescapedValue();
+    result = insertModifiers(event, result);
+    return result;
+  }
+
+  String insertModifiers(TerminalKeyboardEvent event, String action) {
+    String? code;
+
+    if (event.shift && event.alt && event.ctrl) {
+      code = '8';
+    } else if (event.ctrl && event.alt) {
+      code = '7';
+    } else if (event.shift && event.ctrl) {
+      code = '6';
+    } else if (event.ctrl) {
+      code = '5';
+    } else if (event.shift && event.alt) {
+      code = '4';
+    } else if (event.alt) {
+      code = '3';
+    } else if (event.shift) {
+      code = '2';
+    }
+
+    if (code != null) {
+      return action.replaceAll('*', code);
+    }
+
+    return action;
   }
 }
 

--- a/lib/src/core/input/handler.dart
+++ b/lib/src/core/input/handler.dart
@@ -93,22 +93,22 @@ class CascadeInputHandler implements TerminalInputHandler {
 ///
 /// See also:
 ///  * [CascadeInputHandler]
-const defaultInputHandler = CascadeInputHandler([
-  KeytabInputHandler(),
+final defaultInputHandler = CascadeInputHandler([
+  KeytabInputHandler(Keytab.defaultKeytab),
   CtrlInputHandler(),
   AltInputHandler(),
 ]);
 
-final _keytab = Keytab.defaultKeytab();
-
 /// A [TerminalInputHandler] that translates key events according to a keytab
 /// file.
 class KeytabInputHandler implements TerminalInputHandler {
-  const KeytabInputHandler();
+  const KeytabInputHandler(this.keytab);
+
+  final Keytab keytab;
 
   @override
   String? call(TerminalKeyboardEvent event) {
-    final record = _keytab.find(
+    final record = keytab.find(
       event.key,
       ctrl: event.ctrl,
       alt: event.alt,

--- a/lib/src/core/input/handler.dart
+++ b/lib/src/core/input/handler.dart
@@ -108,7 +108,7 @@ class KeytabInputHandler implements TerminalInputHandler {
 
   @override
   String? call(TerminalKeyboardEvent event) {
-    final action = _keytab.find(
+    final record = _keytab.find(
       event.key,
       ctrl: event.ctrl,
       alt: event.alt,
@@ -120,11 +120,11 @@ class KeytabInputHandler implements TerminalInputHandler {
       macos: event.platform == TerminalTargetPlatform.macos,
     );
 
-    if (action == null) {
+    if (record == null) {
       return null;
     }
 
-    var result = action.action.unescapedValue();
+    var result = record.action.unescapedValue();
     result = insertModifiers(event, result);
     return result;
   }

--- a/lib/src/core/input/handler.dart
+++ b/lib/src/core/input/handler.dart
@@ -93,21 +93,23 @@ class CascadeInputHandler implements TerminalInputHandler {
 ///
 /// See also:
 ///  * [CascadeInputHandler]
-final defaultInputHandler = CascadeInputHandler([
-  KeytabInputHandler(Keytab.defaultKeytab),
+const defaultInputHandler = CascadeInputHandler([
+  KeytabInputHandler(),
   CtrlInputHandler(),
   AltInputHandler(),
 ]);
 
 /// A [TerminalInputHandler] that translates key events according to a keytab
-/// file.
+/// file. If no keytab is provided, [Keytab.defaultKeytab] is used.
 class KeytabInputHandler implements TerminalInputHandler {
-  const KeytabInputHandler(this.keytab);
+  const KeytabInputHandler([this.keytab]);
 
-  final Keytab keytab;
+  final Keytab? keytab;
 
   @override
   String? call(TerminalKeyboardEvent event) {
+    final keytab = this.keytab ?? Keytab.defaultKeytab;
+
     final record = keytab.find(
       event.key,
       ctrl: event.ctrl,

--- a/lib/src/core/input/keytab/keytab.dart
+++ b/lib/src/core/input/keytab/keytab.dart
@@ -32,6 +32,7 @@ class Keytab {
     bool newLineMode = false,
     bool appCursorKeys = false,
     bool appKeyPad = false,
+    bool keyPad = false,
     bool appScreen = false,
     bool macos = false,
     // bool meta,
@@ -73,6 +74,10 @@ class Keytab {
       }
 
       if (record.appKeyPad != null && record.appKeyPad != appKeyPad) {
+        continue;
+      }
+
+      if (record.keyPad != null && record.keyPad != keyPad) {
         continue;
       }
 

--- a/lib/src/core/input/keytab/keytab.dart
+++ b/lib/src/core/input/keytab/keytab.dart
@@ -16,9 +16,7 @@ class Keytab {
     return parser.result;
   }
 
-  factory Keytab.defaultKeytab() {
-    return Keytab.parse(kDefaultKeytab);
-  }
+  static final defaultKeytab = Keytab.parse(kDefaultKeytab);
 
   final String? name;
 

--- a/test/src/core/input/handler_test.dart
+++ b/test/src/core/input/handler_test.dart
@@ -1,6 +1,6 @@
 import 'package:test/test.dart';
-import 'package:xterm/src/core/input/keys.dart';
-import 'package:xterm/src/terminal.dart';
+import 'package:xterm/src/core/input/keytab/keytab.dart';
+import 'package:xterm/xterm.dart';
 
 void main() {
   group('defaultInputHandler', () {
@@ -9,6 +9,30 @@ void main() {
       final terminal = Terminal(onOutput: output.add);
       terminal.keyInput(TerminalKey.numpadEnter);
       expect(output, ['\r']);
+    });
+  });
+
+  group('KeytabInputHandler', () {
+    test('can insert modifier code', () {
+      final handler = KeytabInputHandler(
+        Keytab.parse(r'key Home +AnyMod : "\E[1;*H"'),
+      );
+
+      final terminal = Terminal(inputHandler: handler);
+
+      late String output;
+
+      terminal.onOutput = (data) {
+        output = data;
+      };
+
+      terminal.keyInput(TerminalKey.home, ctrl: true);
+
+      expect(output, '\x1b[1;5H');
+
+      terminal.keyInput(TerminalKey.home, shift: true);
+
+      expect(output, '\x1b[1;2H');
     });
   });
 }

--- a/test/src/core/input/keytab/keytab_test.dart
+++ b/test/src/core/input/keytab/keytab_test.dart
@@ -1,0 +1,16 @@
+import 'package:test/test.dart';
+import 'package:xterm/src/core/input/keys.dart';
+import 'package:xterm/src/core/input/keytab/keytab.dart';
+
+void main() {
+  group('Keytab.find()', () {
+    test('can match keyPad', () {
+      final keytab = Keytab.parse(r'key Home +KeyPad : "TEST"');
+      final record = keytab.find(TerminalKey.home, keyPad: true);
+      expect(record!.action.unescapedValue(), 'TEST');
+
+      final record1 = keytab.find(TerminalKey.home);
+      expect(record1, isNull);
+    });
+  });
+}


### PR DESCRIPTION
Hi! Thank you for this library! I decided I can contribute a little.

When I do `Ctrl+V`, `Ctrl+Home` in Termux it writes out `^[[1;5H`
When I do `Ctrl+V`, `Alt+Home` in Termux it writes out `^[[1;3H`
When I do `Ctrl+V`, `Shift+Home` in Termux it writes out `^[[1;2H`

In my app based on this package all of those keystrokes write `^[[H`, same as `Ctrl+V`, `Home`.

After a research I figured that it was happening because "KeyPad" was not checked in in `/lib/src/core/input/keytab/keytab.dart` and following command from `kDefaultKeytab` was picked:
```
key Home        -AppCuKeys+KeyPad : "\E[H"
```

but it was supposed to be following command (it is down the file):

```
key Home        +AnyMod           : "\E[1;*H"
```

After I added KeyPad check it got the correct entry from the default keytab and my app finally wrote out  `^[[1;*H`.

I figured that `*` stands for a modifier code so I googled [and found this](https://invisible-island.net/ncurses/terminfo.src.html#tic-xterm-new) and [also this](https://github.com/tmux/tmux/wiki/Modifier-Keys#modifiers-and-function-keys):
```
# This fragment describes as much of XFree86 xterm's "pc-style" function
# keys as will fit into terminfo's 60 function keys.
# From ctlseqs.ms:
#    Code     Modifiers
#  ---------------------------------
#     2       Shift
#     3       Alt
#     4       Shift + Alt
#     5       Control
#     6       Shift + Control
#     7       Alt + Control
#     8       Shift + Alt + Control
#  ---------------------------------
# The meta key may also be used as a modifier in this scheme, adding another
# bit to the parameter.
```

And then I replaced `*` with corresponding modifier key code. Now `Home` and `End` with modifiers are correctly picked by SSH connection.

Hope this helps