### PR TITLE
Fix designate charset logic

### DIFF
--- a/lib/src/core/escape/handler.dart
+++ b/lib/src/core/escape/handler.dart
@@ -35,7 +35,7 @@ abstract class EscapeHandler {
 
   void reverseIndex();
 
-  void designateCharset(int charset);
+  void designateCharset(int charset, int name);
 
   void unkownEscape(int char);
 

--- a/lib/src/core/escape/parser.dart
+++ b/lib/src/core/escape/parser.dart
@@ -161,15 +161,15 @@ class EscapeParser {
 
   bool _escHandleDesignateCharset0() {
     if (_queue.isEmpty) return false;
-    _queue.consume();
-    handler.designateCharset(0);
+    int name = _queue.consume();
+    handler.designateCharset(0, name);
     return true;
   }
 
   bool _escHandleDesignateCharset1() {
     if (_queue.isEmpty) return false;
-    _queue.consume();
-    handler.designateCharset(1);
+    int name = _queue.consume();
+    handler.designateCharset(1, name);
     return true;
   }
 

--- a/lib/src/terminal.dart
+++ b/lib/src/terminal.dart
@@ -472,8 +472,8 @@ class Terminal with Observable implements TerminalState, EscapeHandler {
   }
 
   @override
-  void designateCharset(int charset) {
-    _buffer.charset.use(charset);
+  void designateCharset(int charset, int name) {
+    _buffer.charset.designate(charset, name);
   }
 
   @override

--- a/lib/src/utils/debugger.dart
+++ b/lib/src/utils/debugger.dart
@@ -164,8 +164,8 @@ class _TerminalDebuggerHandler implements EscapeHandler {
   }
 
   @override
-  void designateCharset(int charset) {
-    onCommand('designateCharset($charset)');
+  void designateCharset(int charset, int name) {
+    onCommand('designateCharset($charset, $name)');
   }
 
   @override

--- a/test/src/core/escape/parser_test.mocks.dart
+++ b/test/src/core/escape/parser_test.mocks.dart
@@ -143,10 +143,10 @@ class MockEscapeHandler extends _i1.Mock implements _i2.EscapeHandler {
         returnValueForMissingStub: null,
       );
   @override
-  void designateCharset(int? charset) => super.noSuchMethod(
+  void designateCharset(int? charset, int? name) => super.noSuchMethod(
         Invocation.method(
           #designateCharset,
-          [charset],
+          [charset, name],
         ),
         returnValueForMissingStub: null,
       );


### PR DESCRIPTION
Sending a designate charset command currently switches to the buffer attempting to be designated instead of setting the buffer's character set. I have updated it to now to change the character set in the appropriate buffer.