### PR TITLE
fix: stop double-emit on macOS when composing characters commit

### DIFF
--- a/lib/src/ui/custom_text_edit.dart
+++ b/lib/src/ui/custom_text_edit.dart
@@ -197,6 +197,15 @@ class CustomTextEditState extends State<CustomTextEdit> with TextInputClient {
 
   late var _currentEditingState = _initEditingState.copyWith();
 
+  // Mirror of the platform's last-reported text in non-deleteDetection mode.
+  // We diff against this instead of [_initEditingState] because some embedders
+  // (notably macOS, when an apostrophe arrives via the composing path) silently
+  // drop the setEditingState() reset we'd otherwise issue after every event.
+  // When that happens, the next keystroke arrives as a cumulative
+  // TextEditingValue, and diffing against a stale init would re-emit
+  // already-emitted characters (e.g. typing "I" + "'" + "d" produced "I''d").
+  late var _seenText = _initEditingState.text;
+
   @override
   TextEditingValue? get currentTextEditingValue {
     return _currentEditingState;
@@ -221,21 +230,38 @@ class CustomTextEditState extends State<CustomTextEdit> with TextInputClient {
 
     widget.onComposing(null);
 
-    if (_currentEditingState.text.length < _initEditingState.text.length) {
-      widget.onDelete();
-    } else {
-      final textDelta = _currentEditingState.text.substring(
-        _initEditingState.text.length,
-      );
-
-      widget.onInsert(textDelta);
+    if (widget.deleteDetection) {
+      // Placeholder-based delete detection (Android soft-keyboard path).
+      // Preserve original semantics: diff against the static placeholder,
+      // emit delete when the field shrinks below it, and reset the platform
+      // state after every event to refill the placeholder so the IME keeps
+      // generating backspace events.
+      if (_currentEditingState.text.length < _initEditingState.text.length) {
+        widget.onDelete();
+      } else {
+        widget.onInsert(
+          _currentEditingState.text.substring(_initEditingState.text.length),
+        );
+      }
+      if (_currentEditingState.text != _initEditingState.text) {
+        _connection!.setEditingState(_initEditingState);
+      }
+      _seenText = _initEditingState.text;
+      return;
     }
 
-    // Reset editing state if composing is done
-    if (_currentEditingState.composing.isCollapsed &&
-        _currentEditingState.text != _initEditingState.text) {
-      _connection!.setEditingState(_initEditingState);
+    // Non-placeholder path. Diff against the platform's last-reported text
+    // rather than the static init state, so the math stays correct even when
+    // setEditingState() didn't take effect on the previous event. We also
+    // skip the post-event reset for the same reason: trying to force the
+    // platform back to init is what created the divergence in the first
+    // place; just letting the platform's text accumulate keeps it
+    // consistent with our mirror.
+    final newText = _currentEditingState.text;
+    if (newText.length > _seenText.length) {
+      widget.onInsert(newText.substring(_seenText.length));
     }
+    _seenText = newText;
   }
 
   @override


### PR DESCRIPTION
## Bug

On macOS Flutter desktop (and possibly other embedders that route printable input through the composing path), typing a key sequence like `I` + `'` + `d` in a `TerminalView` sends `I''d` to the underlying `Terminal`'s `onOutput`, instead of `I'd`. The apostrophe is duplicated.

## Reproducer

Minimal harness on macOS Flutter desktop:

```dart
final terminal = Terminal();
terminal.onOutput = (data) => print('OUT $data codes=${data.codeUnits}');

runApp(MaterialApp(home: Scaffold(body: TerminalView(
  terminal,
  autofocus: true,
  keyboardType: TextInputType.visiblePassword,
))));
```

Focus the view, then type `I` then `'` then `d` on a hardware keyboard. Observed output (before this patch):

```
OUT I codes=[73]
OUT ' codes=[39]
OUT 'd codes=[39, 100]   <-- apostrophe sent twice
```

## Root cause

`CustomTextEdit.updateEditingValue` (`lib/src/ui/custom_text_edit.dart`) resets the platform's editing state back to `_initEditingState` after every successful insert via `_connection!.setEditingState(_initEditingState)`. On macOS, that reset is silently dropped when the previous insert came through the composing path — typing the apostrophe arrives as two events from the engine:

1. `text='\''`, `composing=(0, 1)` — handled by the composing branch, which returns early without calling the reset.
2. `text='\''`, `composing=(-1, -1)` — collapses; `onInsert("'")` fires, the reset is requested, but the platform never actually applies it.

So when `d` is pressed next, the platform reports `text="'d"` instead of `text="d"` (the apostrophe never cleared from its view). The existing diff `text.substring(_initEditingState.text.length)` therefore evaluates to `"'d"` and `onInsert("'d")` re-emits the apostrophe that was already sent.

I confirmed this with instrumented `debugPrint`s in `updateEditingValue` — full event trace in the linked downstream commit.

## Fix

Track the platform's last-reported text in a local `_seenText` mirror and diff inserts against that instead of the static `_initEditingState`. The mirror keeps the diff math correct whether or not `setEditingState()` actually took. In the non-`deleteDetection` path, the post-event reset is also dropped — it was the source of the divergence in the first place; letting the platform's text accumulate keeps it consistent with the mirror.

`deleteDetection` mode (Android soft-keyboard placeholder-backspace detection) keeps the original placeholder-and-reset behavior. Removing the reset there would break the IME's ability to keep emitting backspace events when the placeholder gets consumed, so that path is preserved verbatim.

The patch is a single-file change in `lib/src/ui/custom_text_edit.dart`.

## Verification

- Same harness as above, after the patch:
  ```
  OUT I codes=[73]
  OUT ' codes=[39]
  OUT d codes=[100]   <-- correct
  ```
- `dart format --set-exit-if-changed lib/src/ui/custom_text_edit.dart` → clean (0 files changed).
- Followed by manual smoke testing in a downstream Flutter app on macOS: real terminal sessions, typing prose with multiple apostrophes, paste, backspace, hardware-key shortcuts — all behave normally.

## What I haven't done

- **No widget/unit test in this PR.** The closest existing test, `test/frontend/input_test.dart`, is entirely commented out and references an older API that no longer exists. A proper test would drive `binding.testTextInput.updateEditingValue(...)` with the macOS-style cumulative-state sequence directly. Happy to add one if you'd like — let me know what shape you want it in.
- I couldn't run `flutter analyze` locally because the current `pubspec.yaml` depends on `dart_code_metrics ^5.0.0`, which is abandoned and conflicts with modern `flutter_test`. That's a pre-existing issue, not introduced by this patch.

## Known edge cases

The new diff math assumes that meaningful text growth in the IME's view corresponds to newly typed characters. A few situations don't fit that model and are worth flagging:

- **OS-level text replacement** (macOS Settings → Keyboard → Text Replacements, e.g. `omw` → `On my way!`) would now emit only the tail rather than the full snippet; with the previous code it would emit the full snippet on top of the already-typed prefix. Both behaviors are wrong, just differently — and `autocorrect: false` / `enableSuggestions: false` already suppress most cases on iOS/Android.
- **Long-running sessions** no longer reset the platform's text buffer, so the IME's internal text grows unboundedly. In practice this is fine for typical terminal use; it would only become visible if an embedder did per-character work proportional to text length.

Happy to discuss either of these further if you want a follow-up to address them more thoroughly.