### PR TITLE
fix: add viewId to TextInputConfiguration for Flutter 3.44+ Windows

### DIFF
--- a/lib/src/ui/custom_text_edit.dart
+++ b/lib/src/ui/custom_text_edit.dart
@@ -160,6 +160,7 @@ class CustomTextEditState extends State<CustomTextEdit> with TextInputClient {
       _connection!.show();
     } else {
       final config = TextInputConfiguration(
+        viewId: View.of(context).viewId,
         inputType: widget.inputType,
         inputAction: widget.inputAction,
         keyboardAppearance: widget.keyboardAppearance,


### PR DESCRIPTION
On Windows desktop with Flutter 3.44+, text input in the terminal requires `viewId` to be passed to `TextInputConfiguration`.

Without this, `TextInput.attach()` cannot properly route text input on Windows, resulting in unresponsive keyboard input in the terminal.